### PR TITLE
sync SyncProfile CRD to helm chart and add sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,10 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 HELM_CHART_DIR ?= charts/ignition-sync-operator
 
 .PHONY: helm-sync
-helm-sync: manifests ## Sync CRD and verify RBAC between kustomize config and Helm chart.
+helm-sync: manifests ## Sync CRDs and verify RBAC between kustomize config and Helm chart.
 	@cp config/crd/bases/sync.ignition.io_ignitionsyncs.yaml $(HELM_CHART_DIR)/crds/
-	@echo "CRD copied to $(HELM_CHART_DIR)/crds/"
+	@cp config/crd/bases/sync.ignition.io_syncprofiles.yaml $(HELM_CHART_DIR)/crds/
+	@echo "CRDs copied to $(HELM_CHART_DIR)/crds/"
 	@diff <(sed -n '/^rules:/,$$p' config/rbac/role.yaml | sed 's/^[[:space:]]*//' | grep -v '^$$') \
 	      <(sed -n '/^rules:/,$$p' $(HELM_CHART_DIR)/templates/clusterrole.yaml | sed 's/^[[:space:]]*//' | grep -v '^$$') \
 	  && echo "RBAC rules in sync" \

--- a/charts/ignition-sync-operator/crds/sync.ignition.io_syncprofiles.yaml
+++ b/charts/ignition-sync-operator/crds/sync.ignition.io_syncprofiles.yaml
@@ -17,10 +17,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Number of source→dest mappings
-      jsonPath: .spec.mappings
-      name: Mappings
-      type: integer
     - jsonPath: .spec.deploymentMode.name
       name: Mode
       type: string

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,5 @@
 ## Append samples of your project ##
 resources:
 - sync_v1alpha1_ignitionsync.yaml
+- sync_v1alpha1_syncprofile.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/sync_v1alpha1_syncprofile.yaml
+++ b/config/samples/sync_v1alpha1_syncprofile.yaml
@@ -1,0 +1,14 @@
+apiVersion: sync.ignition.io/v1alpha1
+kind: SyncProfile
+metadata:
+  name: syncprofile-sample
+spec:
+  mappings:
+    - source: "projects/"
+      destination: "projects/"
+      type: dir
+      required: true
+    - source: "config/tags/"
+      destination: "tags/"
+      type: dir
+  syncPeriod: 30


### PR DESCRIPTION
## Summary
- `make helm-sync` now copies both IgnitionSync and SyncProfile CRDs to the Helm chart, fixing the stale SyncProfile CRD that still had the broken `Mappings` printcolumn
- Adds a minimal `SyncProfile` sample (`config/samples/sync_v1alpha1_syncprofile.yaml`) with two dir mappings

## Test plan
- [ ] `make helm-sync` succeeds and copies both CRDs
- [ ] `kubectl apply --dry-run=client -f config/samples/sync_v1alpha1_syncprofile.yaml` validates
- [ ] No `Mappings` printcolumn in the helm chart CRD