### PR TITLE
fix reconcile storm and unblock webhook-triggered syncs

### DIFF
--- a/internal/controller/ignitionsync_controller_test.go
+++ b/internal/controller/ignitionsync_controller_test.go
@@ -261,7 +261,6 @@ var _ = Describe("IgnitionSync Controller", func() {
 			Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
 			Expect(cm.Data["commit"]).To(Equal("abc123def"))
 			Expect(cm.Data["ref"]).To(Equal("main"))
-			Expect(cm.Data["trigger"]).NotTo(BeEmpty())
 
 			// Git client should have been called exactly once
 			Expect(gitClient.calls).To(Equal(1))


### PR DESCRIPTION
## Summary
- Remove `time.Now()` trigger key from metadata ConfigMap — it changed every reconcile, causing the `Owns(&ConfigMap{})` watch to re-trigger indefinitely
- Add `reflect.DeepEqual` guard before ConfigMap updates to skip no-ops
- Replace `GenerationChangedPredicate` with a custom predicate that also passes annotation changes, so the webhook receiver's `AnnotationRequestedRef` triggers immediate reconciles instead of waiting for the next poll

## Test plan
- [ ] `make test` passes (15 tests)
- [ ] Controller no longer reconciles every ~5s on a stable CR
- [ ] Webhook receiver annotation change triggers immediate reconcile