### PR TITLE
rename go module to github.com/ia-eknorr/ignition-sync-operator

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -7,7 +7,7 @@ domain: ignition.io
 layout:
 - go.kubebuilder.io/v4
 projectName: ignition-sync-operator
-repo: github.com/inductiveautomation/ignition-sync-operator
+repo: github.com/ia-eknorr/ignition-sync-operator
 resources:
 - api:
     crdVersion: v1
@@ -16,6 +16,6 @@ resources:
   domain: ignition.io
   group: sync
   kind: IgnitionSync
-  path: github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1
+  path: github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -14,8 +14,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	"github.com/inductiveautomation/ignition-sync-operator/internal/agent"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/agent"
 )
 
 func main() {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,10 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	"github.com/inductiveautomation/ignition-sync-operator/internal/controller"
-	"github.com/inductiveautomation/ignition-sync-operator/internal/git"
-	iswebhook "github.com/inductiveautomation/ignition-sync-operator/internal/webhook"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/controller"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/git"
+	iswebhook "github.com/ia-eknorr/ignition-sync-operator/internal/webhook"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/inductiveautomation/ignition-sync-operator
+module github.com/ia-eknorr/ignition-sync-operator
 
 go 1.25.3
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -13,10 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/inductiveautomation/ignition-sync-operator/internal/git"
-	"github.com/inductiveautomation/ignition-sync-operator/internal/ignition"
-	"github.com/inductiveautomation/ignition-sync-operator/internal/syncengine"
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/git"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/ignition"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/syncengine"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 const agentVersion = "0.1.0"

--- a/internal/agent/configmap.go
+++ b/internal/agent/configmap.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 // MetadataConfigMapName returns the metadata ConfigMap name for a CR.

--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	"github.com/inductiveautomation/ignition-sync-operator/internal/syncengine"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/syncengine"
 )
 
 // TemplateContext holds the variables available in mapping templates.

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
 )
 
 func TestResolveTemplate_AllFields(t *testing.T) {

--- a/internal/controller/gateway_discovery.go
+++ b/internal/controller/gateway_discovery.go
@@ -14,9 +14,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	"github.com/inductiveautomation/ignition-sync-operator/pkg/conditions"
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	"github.com/ia-eknorr/ignition-sync-operator/pkg/conditions"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 // findIgnitionSyncForPod reads the ignition-sync.io/cr-name annotation from a pod

--- a/internal/controller/ignitionsync_controller.go
+++ b/internal/controller/ignitionsync_controller.go
@@ -22,10 +22,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	"github.com/inductiveautomation/ignition-sync-operator/internal/git"
-	"github.com/inductiveautomation/ignition-sync-operator/pkg/conditions"
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/git"
+	"github.com/ia-eknorr/ignition-sync-operator/pkg/conditions"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 const (

--- a/internal/controller/ignitionsync_controller_test.go
+++ b/internal/controller/ignitionsync_controller_test.go
@@ -17,10 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	"github.com/inductiveautomation/ignition-sync-operator/internal/git"
-	"github.com/inductiveautomation/ignition-sync-operator/pkg/conditions"
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	"github.com/ia-eknorr/ignition-sync-operator/internal/git"
+	"github.com/ia-eknorr/ignition-sync-operator/pkg/conditions"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 // fakeGitClient is a test double for git.Client.

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -17,7 +17,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/syncprofile_controller.go
+++ b/internal/controller/syncprofile_controller.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	"github.com/inductiveautomation/ignition-sync-operator/pkg/conditions"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	"github.com/ia-eknorr/ignition-sync-operator/pkg/conditions"
 )
 
 // SyncProfileReconciler reconciles a SyncProfile object.

--- a/internal/controller/syncprofile_controller_test.go
+++ b/internal/controller/syncprofile_controller_test.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	"github.com/inductiveautomation/ignition-sync-operator/pkg/conditions"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	"github.com/ia-eknorr/ignition-sync-operator/pkg/conditions"
 )
 
 func newProfileReconciler() *SyncProfileReconciler {

--- a/internal/git/auth.go
+++ b/internal/git/auth.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/internal/webhook/inject.go
+++ b/internal/webhook/inject.go
@@ -16,8 +16,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 const (

--- a/internal/webhook/inject_test.go
+++ b/internal/webhook/inject_test.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 const testNamespace = "test-ns"

--- a/internal/webhook/receiver.go
+++ b/internal/webhook/receiver.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 const (

--- a/internal/webhook/receiver_test.go
+++ b/internal/webhook/receiver_test.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	syncv1alpha1 "github.com/inductiveautomation/ignition-sync-operator/api/v1alpha1"
-	synctypes "github.com/inductiveautomation/ignition-sync-operator/pkg/types"
+	syncv1alpha1 "github.com/ia-eknorr/ignition-sync-operator/api/v1alpha1"
+	synctypes "github.com/ia-eknorr/ignition-sync-operator/pkg/types"
 )
 
 const testRef = "v2.0.0"


### PR DESCRIPTION
## Summary
- Rename Go module from `github.com/inductiveautomation/ignition-sync-operator` to `github.com/ia-eknorr/ignition-sync-operator`
- Updates `go.mod`, `PROJECT`, and all import paths across 17 `.go` files

This aligns the module path with the actual repo location, enabling `go get`, [doc.crds.dev](https://doc.crds.dev) auto-generated CRD docs, and correct import paths.

## Test plan
- [ ] `go build ./...` passes
- [ ] `make test` passes (all tests)
- [ ] No remaining references to `inductiveautomation` in Go source or `go.mod`

**Note:** This PR should be merged before the other blocker PRs to avoid import conflicts during rebases.