### PR TITLE
wire webhook HMAC secret through Helm chart

### DIFF
--- a/charts/ignition-sync-operator/templates/deployment.yaml
+++ b/charts/ignition-sync-operator/templates/deployment.yaml
@@ -39,6 +39,16 @@ spec:
           env:
             - name: DEFAULT_AGENT_IMAGE
               value: "{{ .Values.agentImage.repository }}:{{ .Values.agentImage.tag | default .Chart.AppVersion }}"
+            {{- if .Values.webhookReceiver.hmac.secretRef.name }}
+            - name: WEBHOOK_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.webhookReceiver.hmac.secretRef.name }}
+                  key: {{ .Values.webhookReceiver.hmac.secretRef.key }}
+            {{- else if .Values.webhookReceiver.hmac.secret }}
+            - name: WEBHOOK_HMAC_SECRET
+              value: {{ .Values.webhookReceiver.hmac.secret | quote }}
+            {{- end }}
           ports:
           {{- if .Values.webhook.enabled }}
             - containerPort: {{ .Values.webhook.port | default 9443 }}

--- a/charts/ignition-sync-operator/values.yaml
+++ b/charts/ignition-sync-operator/values.yaml
@@ -89,6 +89,17 @@ certManager:
 webhookReceiver:
   # -- Port for the inbound git webhook receiver. Set to 0 to disable.
   port: 9444
+  # -- HMAC secret for validating webhook signatures (X-Hub-Signature-256).
+  # Provide either a literal value or a reference to an existing Secret.
+  hmac:
+    # -- HMAC secret value. Ignored if secretRef is set.
+    secret: ""
+    # -- Reference to an existing Secret containing the HMAC key.
+    secretRef:
+      # -- Name of the Secret.
+      name: ""
+      # -- Key within the Secret.
+      key: "webhook-secret"
 
 # -- Node selector labels for scheduling the controller pod.
 # Example:


### PR DESCRIPTION
## Summary
- Add `webhookReceiver.hmac` config to values.yaml (literal value or secretRef)
- Wire `WEBHOOK_HMAC_SECRET` env var into deployment template
- SecretRef takes priority over literal value for security

## Test plan
- [ ] `helm template` with no HMAC config renders no env var
- [ ] `--set webhookReceiver.hmac.secret=foo` renders literal value
- [ ] `--set webhookReceiver.hmac.secretRef.name=my-secret` renders secretKeyRef