### PR TITLE
add liveness and readiness probes to agent sidecar

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -17,5 +17,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /
 COPY --from=builder /workspace/agent .
 USER 65534:65534
+EXPOSE 8082
 
 ENTRYPOINT ["/agent"]

--- a/internal/webhook/inject.go
+++ b/internal/webhook/inject.go
@@ -225,6 +225,26 @@ func injectSidecar(pod *corev1.Pod, isync *syncv1alpha1.IgnitionSync) {
 			PeriodSeconds:    2,
 			FailureThreshold: 30,
 		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.FromInt32(8082),
+				},
+			},
+			PeriodSeconds:    10,
+			FailureThreshold: 3,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.FromInt32(8082),
+				},
+			},
+			PeriodSeconds:    5,
+			FailureThreshold: 3,
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: volumeSyncRepo, MountPath: mountRepo},
 			{Name: volumeGitCredentials, MountPath: mountGitCredentials, ReadOnly: true},


### PR DESCRIPTION
## Summary
- Add LivenessProbe (/healthz, period 10s) and ReadinessProbe (/readyz, period 5s) to injected sidecar
- Expose port 8082 in Dockerfile.agent
- Health server endpoints already implemented in internal/agent/health.go

## Test plan
- [ ] `go build ./...` passes
- [ ] Injected sidecar has all three probes (startup, liveness, readiness)
- [ ] Agent pod shows Ready after initial sync completes