### PR TITLE
make agent logging configurable, default to production mode

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -19,10 +19,11 @@ import (
 )
 
 func main() {
-	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	devMode := os.Getenv("LOG_DEV_MODE") == "true"
+	logf.SetLogger(zap.New(zap.UseDevMode(devMode)))
 	log := logf.Log.WithName("agent")
 
-	log.Info("ignition-sync-agent starting")
+	log.Info("ignition-sync-agent starting", "devMode", devMode)
 
 	// Load configuration from environment.
 	cfg, err := agent.LoadConfig()


### PR DESCRIPTION
## Summary
- Replace hardcoded `UseDevMode(true)` with env-var-driven config
- Default: production mode (JSON, info-level) for log aggregation
- Set `LOG_DEV_MODE=true` for console encoder with debug-level output

## Test plan
- [ ] `go build ./...` passes
- [ ] Agent defaults to structured JSON logging (no LOG_DEV_MODE set)
- [ ] Agent uses console encoder when LOG_DEV_MODE=true