### PR TITLE
fix CopyIgnoredFile warning in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,19 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore everything by default and re-include only needed files
-**
+# Exclude non-source directories from build context
+.git
+.github
+charts
+config
+docs
+hack
+secrets
+test
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
+# Exclude non-source files
 **/*_test.go
-
-# Re-include Go module files
-!go.mod
-!go.sum
+*.md
+Makefile
+LICENSE
+.dockerignore
+.gitignore
+.golangci.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the Go source (relies on .dockerignore to filter)
-COPY . .
+# Copy the Go source
+COPY api/ api/
+COPY cmd/ cmd/
+COPY internal/ internal/
+COPY pkg/ pkg/
 
 # Build controller
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/controller/main.go

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -8,7 +8,10 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
 
-COPY . .
+COPY api/ api/
+COPY cmd/ cmd/
+COPY internal/ internal/
+COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o agent cmd/agent/main.go
 


### PR DESCRIPTION
### 📖 Background
Release builds show a `CopyIgnoredFile` warning because the deny-all `.dockerignore` (`**` + `!` re-includes) causes BuildKit's linter to flag every `COPY` source as excluded.

### ⚙️ Changes
- Replace `COPY . .` with explicit `COPY api/ api/` etc. in both `Dockerfile` and `Dockerfile.agent`
- Flip `.dockerignore` from deny-all to traditional exclude-what-you-don't-need

### 📝 Reviewer Notes
The explicit COPY approach also improves layer caching — a change to `cmd/` no longer invalidates the layer containing `internal/`.

### ☑️ Testing Notes
- Verify no `CopyIgnoredFile` warnings on next release build
- `docker build -f Dockerfile .` and `docker build -f Dockerfile.agent .` should succeed locally