### PR TITLE
add designer session detection and dependsOn cycle detection

### DIFF
--- a/api/v1alpha1/syncprofile_types.go
+++ b/api/v1alpha1/syncprofile_types.go
@@ -51,6 +51,14 @@ type SyncProfileSpec struct {
 	// +optional
 	DryRun bool `json:"dryRun,omitempty"`
 
+	// designerSessionPolicy controls sync behavior when Ignition Designer
+	// sessions are active. "proceed" (default) logs a warning and continues,
+	// "wait" retries until sessions close (up to 5 min), "fail" aborts the sync.
+	// +kubebuilder:default="proceed"
+	// +kubebuilder:validation:Enum=proceed;wait;fail
+	// +optional
+	DesignerSessionPolicy string `json:"designerSessionPolicy,omitempty"`
+
 	// paused halts sync for all gateways referencing this profile.
 	// +optional
 	Paused bool `json:"paused,omitempty"`

--- a/config/crd/bases/sync.ignition.io_syncprofiles.yaml
+++ b/config/crd/bases/sync.ignition.io_syncprofiles.yaml
@@ -99,6 +99,17 @@ spec:
                 - name
                 - source
                 type: object
+              designerSessionPolicy:
+                default: proceed
+                description: |-
+                  designerSessionPolicy controls sync behavior when Ignition Designer
+                  sessions are active. "proceed" (default) logs a warning and continues,
+                  "wait" retries until sessions close (up to 5 min), "fail" aborts the sync.
+                enum:
+                - proceed
+                - wait
+                - fail
+                type: string
               dryRun:
                 description: |-
                   dryRun causes the agent to sync to a staging directory without

--- a/internal/ignition/designer.go
+++ b/internal/ignition/designer.go
@@ -1,0 +1,60 @@
+package ignition
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// DesignerSession represents an active Ignition Designer session.
+// Field names match the Ignition 8.3 REST API (GET /data/api/v1/designers).
+type DesignerSession struct {
+	ID       string `json:"id"`
+	User     string `json:"user"`
+	Project  string `json:"project"`
+	Address  string `json:"address"`
+	Timezone string `json:"timezone"`
+	Uptime   int64  `json:"uptime"`
+}
+
+// designerListResponse is the standard Ignition list envelope.
+type designerListResponse struct {
+	Items []DesignerSession `json:"items"`
+}
+
+// GetDesignerSessions queries the gateway for active Designer sessions.
+// Returns an empty slice when no designers are connected.
+func (c *Client) GetDesignerSessions(ctx context.Context) ([]DesignerSession, error) {
+	url := c.BaseURL + "/data/api/v1/designers"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating designer sessions request: %w", err)
+	}
+	c.setAuth(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching designer sessions: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("designer sessions API returned HTTP %d", resp.StatusCode)
+	}
+
+	var envelope designerListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("decoding designer sessions response: %w", err)
+	}
+
+	if envelope.Items == nil {
+		return []DesignerSession{}, nil
+	}
+	return envelope.Items, nil
+}

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -33,4 +33,6 @@ const (
 	ReasonValidationFailed    = "ValidationFailed"
 	ReasonSidecarMissing      = "SidecarMissing"
 	ReasonSidecarPresent      = "SidecarPresent"
+	ReasonCycleDetected       = "CycleDetected"
+	ReasonDependencyNotFound  = "DependencyNotFound"
 )

--- a/pkg/types/sync_status.go
+++ b/pkg/types/sync_status.go
@@ -61,4 +61,7 @@ type GatewayStatus struct {
 
 	// DryRunDiffDeleted is the count of files that would be removed.
 	DryRunDiffDeleted int32 `json:"dryRunDiffDeleted,omitempty"`
+
+	// DesignerSessionsBlocked indicates the agent is waiting for designer sessions to close.
+	DesignerSessionsBlocked bool `json:"designerSessionsBlocked,omitempty"`
 }


### PR DESCRIPTION
## Summary

- **Designer session pre-sync check**: Agent queries `GET /data/api/v1/designers` before syncing files. New `SyncProfile.spec.designerSessionPolicy` field (enum: `proceed`/`wait`/`fail`, default `proceed`) controls behavior when designers are active. `wait` retries every 10s for up to 5 minutes and reports `DesignerSessionsBlocked` in the status ConfigMap.
- **dependsOn cycle detection**: SyncProfile controller validates that `dependsOn` references exist and runs DFS cycle detection. Sets `Accepted=False` with `CycleDetected` or `DependencyNotFound` reasons.
- **5 new controller tests**: self-dependency, direct cycle, 3-node cycle, missing dependency, valid chain (25/25 passing)

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/controller/...` — 25/25 pass (includes 5 new cycle detection tests)
- [ ] Manual: apply a SyncProfile with `dependsOn` cycle, verify `Accepted=False` with `CycleDetected`
- [ ] Manual: open a Designer session, trigger sync with `designerSessionPolicy: fail`, verify sync is skipped