### PR TITLE
rename helm values for clarity, add NOTES.txt, fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Kubernetes operator that continuously syncs Ignition gateway configuration fro
 
 ```bash
 # Install the operator
-helm install ignition-sync oci://ghcr.io/inductiveautomation/charts/ignition-sync-operator
+helm install ignition-sync oci://ghcr.io/ia-eknorr/charts/ignition-sync-operator
 
 # Create a git auth secret
 kubectl create secret generic git-creds --from-literal=token=ghp_...
@@ -37,7 +37,7 @@ kubectl apply -f config/samples/sync_v1alpha1_ignitionsync.yaml
 kubectl apply -f config/samples/sync_v1alpha1_syncprofile.yaml
 
 # Label the namespace for sidecar injection
-kubectl label namespace default ignition-sync.io/inject=enabled
+kubectl label namespace default ignition-sync.io/injection=enabled
 
 # Grant the agent RBAC in your namespace
 kubectl create rolebinding ignition-sync-agent \

--- a/charts/ignition-sync-operator/templates/NOTES.txt
+++ b/charts/ignition-sync-operator/templates/NOTES.txt
@@ -1,0 +1,71 @@
+Ignition Sync Operator has been installed in namespace {{ .Release.Namespace }}.
+
+== Next Steps ==
+
+1. Create secrets for git authentication and gateway API access:
+
+    kubectl create secret generic git-creds -n <namespace> \
+      --from-literal=token=<your-git-token>
+
+    kubectl create secret generic gw-api-key -n <namespace> \
+      --from-literal=apiKey=<token-name>:<token-secret>
+
+2. Apply an IgnitionSync CR to define the git repository:
+
+    apiVersion: sync.ignition.io/v1alpha1
+    kind: IgnitionSync
+    metadata:
+      name: my-sync
+    spec:
+      git:
+        repo: "https://github.com/your-org/ignition-config.git"
+        ref: "main"
+        auth:
+          token:
+            secretRef:
+              name: git-creds
+              key: token
+      gateway:
+        apiKeySecretRef:
+          name: gw-api-key
+          key: apiKey
+
+3. Apply a SyncProfile to define file mappings:
+
+    apiVersion: sync.ignition.io/v1alpha1
+    kind: SyncProfile
+    metadata:
+      name: my-profile
+    spec:
+      mappings:
+        - source: "projects/"
+          destination: "projects/"
+          type: dir
+          required: true
+      syncPeriod: 30
+
+4. Label the namespace for sidecar injection:
+
+    kubectl label namespace <namespace> ignition-sync.io/injection=enabled
+
+5. Grant the agent RBAC in each namespace where gateways run:
+
+    kubectl create rolebinding ignition-sync-agent -n <namespace> \
+      --clusterrole={{ include "ignition-sync-operator.fullname" . }}-agent \
+      --serviceaccount=<namespace>:<gateway-service-account>
+
+6. Add the injection annotation to your Ignition gateway pod template:
+
+    podAnnotations:
+      ignition-sync.io/inject: "true"
+      ignition-sync.io/sync-profile: "my-profile"
+
+{{- if and .Values.injection.enabled .Values.certManager.enabled }}
+
+== cert-manager ==
+
+TLS certificates for sidecar injection are managed by cert-manager.
+Ensure cert-manager is installed: https://cert-manager.io/docs/installation/
+{{- end }}
+
+For documentation, see: https://github.com/ia-eknorr/ignition-sync-operator

--- a/charts/ignition-sync-operator/templates/deployment.yaml
+++ b/charts/ignition-sync-operator/templates/deployment.yaml
@@ -32,26 +32,26 @@ spec:
             - --leader-elect
             {{- end }}
             - --health-probe-bind-address=:8081
-          {{- if and .Values.webhook.enabled .Values.certManager.enabled }}
+          {{- if and .Values.injection.enabled .Values.certManager.enabled }}
             - --webhook-cert-path=/etc/webhook-certs
           {{- end }}
-            - --webhook-receiver-port={{ .Values.webhookReceiver.port | default 9444 }}
+            - --webhook-receiver-port={{ .Values.pushReceiver.port | default 9444 }}
           env:
             - name: DEFAULT_AGENT_IMAGE
               value: "{{ .Values.agentImage.repository }}:{{ .Values.agentImage.tag | default .Chart.AppVersion }}"
-            {{- if .Values.webhookReceiver.hmac.secretRef.name }}
+            {{- if .Values.pushReceiver.hmac.secretRef.name }}
             - name: WEBHOOK_HMAC_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.webhookReceiver.hmac.secretRef.name }}
-                  key: {{ .Values.webhookReceiver.hmac.secretRef.key }}
-            {{- else if .Values.webhookReceiver.hmac.secret }}
+                  name: {{ .Values.pushReceiver.hmac.secretRef.name }}
+                  key: {{ .Values.pushReceiver.hmac.secretRef.key }}
+            {{- else if .Values.pushReceiver.hmac.secret }}
             - name: WEBHOOK_HMAC_SECRET
-              value: {{ .Values.webhookReceiver.hmac.secret | quote }}
+              value: {{ .Values.pushReceiver.hmac.secret | quote }}
             {{- end }}
           ports:
-          {{- if .Values.webhook.enabled }}
-            - containerPort: {{ .Values.webhook.port | default 9443 }}
+          {{- if .Values.injection.enabled }}
+            - containerPort: {{ .Values.injection.port | default 9443 }}
               name: webhook-server
               protocol: TCP
           {{- else }}
@@ -80,7 +80,7 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
-            {{- if and .Values.webhook.enabled .Values.certManager.enabled }}
+            {{- if and .Values.injection.enabled .Values.certManager.enabled }}
             - mountPath: /etc/webhook-certs
               name: cert
               readOnly: true
@@ -88,7 +88,7 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
-        {{- if and .Values.webhook.enabled .Values.certManager.enabled }}
+        {{- if and .Values.injection.enabled .Values.certManager.enabled }}
         - name: cert
           secret:
             defaultMode: 420

--- a/charts/ignition-sync-operator/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/ignition-sync-operator/templates/mutatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled }}
+{{- if .Values.injection.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/charts/ignition-sync-operator/templates/selfsigned-issuer.yaml
+++ b/charts/ignition-sync-operator/templates/selfsigned-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.webhook.enabled .Values.certManager.enabled }}
+{{- if and .Values.injection.enabled .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/charts/ignition-sync-operator/templates/webhook-certificate.yaml
+++ b/charts/ignition-sync-operator/templates/webhook-certificate.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.webhook.enabled .Values.certManager.enabled }}
+{{- if and .Values.injection.enabled .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/ignition-sync-operator/templates/webhook-service.yaml
+++ b/charts/ignition-sync-operator/templates/webhook-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled }}
+{{- if .Values.injection.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,7 +10,7 @@ spec:
   ports:
     - port: 443
       protocol: TCP
-      targetPort: {{ .Values.webhook.port | default 9443 }}
+      targetPort: {{ .Values.injection.port | default 9443 }}
   selector:
     {{- include "ignition-sync-operator.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/ignition-sync-operator/values.yaml
+++ b/charts/ignition-sync-operator/values.yaml
@@ -69,27 +69,28 @@ networkPolicy:
   # -- Create a NetworkPolicy for the controller.
   enabled: false
 
-# -- Mutating webhook for sidecar injection. When enabled, pods with annotation
+# -- Sidecar injection via MutatingWebhook. When enabled, pods with annotation
 # `ignition-sync.io/inject: "true"` in labeled namespaces get the sync-agent
 # sidecar injected automatically.
-webhook:
-  # -- Enable the MutatingWebhookConfiguration and webhook Service.
+injection:
+  # -- Enable the MutatingWebhookConfiguration and injection Service.
   enabled: true
   # -- Webhook server port on the controller container.
   port: 9443
 
-# -- cert-manager integration for webhook TLS certificates.
+# -- cert-manager integration for injection webhook TLS certificates.
 # Requires cert-manager to be installed in the cluster.
 certManager:
-  # -- Create a self-signed Issuer and Certificate for webhook TLS.
+  # -- Create a self-signed Issuer and Certificate for injection webhook TLS.
   # Requires cert-manager to be installed in the cluster.
   enabled: true
 
-# -- Git webhook receiver for push-event-driven sync.
-webhookReceiver:
-  # -- Port for the inbound git webhook receiver. Set to 0 to disable.
+# -- Git push receiver for event-driven sync. Accepts POST from GitHub/GitLab
+# webhooks at /webhook/{namespace}/{crName}.
+pushReceiver:
+  # -- Port for the inbound push receiver. Set to 0 to disable.
   port: 9444
-  # -- HMAC secret for validating webhook signatures (X-Hub-Signature-256).
+  # -- HMAC secret for validating push receiver signatures (X-Hub-Signature-256).
   # Provide either a literal value or a reference to an existing Secret.
   hmac:
     # -- HMAC secret value. Ignored if secretRef is set.


### PR DESCRIPTION
### 📖 Background

The Helm chart had two confusingly similar "webhook" concepts in values.yaml: `webhook` (sidecar injection) and `webhookReceiver` (git push events). First-time users also got zero post-install guidance and the README had a wrong OCI registry URL and namespace label.

### ⚙️ Changes

- Rename values.yaml keys: `webhook` → `injection`, `webhookReceiver` → `pushReceiver`
- Update all template references to use the new keys
- Add `NOTES.txt` with post-install setup steps (secrets, CRs, namespace label, agent RBAC, SyncProfile)
- Fix README OCI URL: `inductiveautomation` → `ia-eknorr`
- Fix README namespace label: `ignition-sync.io/inject` → `ignition-sync.io/injection`

### 📝 Reviewer Notes

K8s resource names (e.g. `*-webhook-service`, `*-webhook-cert`) are intentionally unchanged — only user-facing values.yaml keys were renamed. Go code and controller flags are not touched in this PR.

### ☑️ Testing Notes

- `helm template test charts/ignition-sync-operator/` renders without errors
- `helm template test charts/ignition-sync-operator/ --set injection.enabled=false` excludes all webhook resources
- `helm install test charts/ignition-sync-operator/ --dry-run` shows NOTES.txt with correct guidance