### PR TITLE
add helm-docs for chart values documentation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,21 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.7.2
+
+  helm-docs:
+    name: Helm Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Install helm-docs
+        run: |
+          HELM_DOCS_VERSION=v1.14.2
+          curl -fsSL "https://github.com/norwoodj/helm-docs/releases/download/${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION#v}_Linux_x86_64.tar.gz" \
+            | tar xz -C /usr/local/bin helm-docs
+
+      - name: Verify chart README is up to date
+        run: |
+          helm-docs --chart-search-root charts
+          git diff --exit-code charts/

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+HELM_DOCS = $(LOCALBIN)/helm-docs
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
@@ -200,6 +201,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
 GOLANGCI_LINT_VERSION ?= v2.7.2
+HELM_DOCS_VERSION ?= v1.14.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -227,6 +229,13 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: helm-docs
+helm-docs: $(HELM_DOCS) ## Generate Helm chart README from values.yaml comments.
+	"$(HELM_DOCS)" --chart-search-root charts
+
+$(HELM_DOCS): $(LOCALBIN)
+	$(call go-install-tool,$(HELM_DOCS),github.com/norwoodj/helm-docs/cmd/helm-docs,$(HELM_DOCS_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/charts/ignition-sync-operator/README.md
+++ b/charts/ignition-sync-operator/README.md
@@ -1,0 +1,85 @@
+# ignition-sync-operator
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+Kubernetes operator that syncs Ignition gateway projects from a Git repository
+
+**Homepage:** <https://github.com/ia-eknorr/ignition-sync-operator>
+
+## Prerequisites
+
+- Kubernetes >= 1.28
+- Helm 3
+- [cert-manager](https://cert-manager.io/) (when `certManager.enabled=true`)
+
+## Installation
+
+```bash
+helm install ignition-sync oci://ghcr.io/ia-eknorr/charts/ignition-sync-operator
+```
+
+See the post-install notes (`helm get notes <release>`) for next steps: creating
+secrets, applying CRs, labeling namespaces, and granting agent RBAC.
+
+## Architecture
+
+The operator has two components:
+
+- **Controller** — watches IgnitionSync and SyncProfile CRs, resolves git refs
+  via `ls-remote`, and manages metadata ConfigMaps.
+- **Agent sidecar** — injected into gateway pods via MutatingWebhook, clones the
+  repo and syncs files to the Ignition data directory.
+
+Two webhook-like features exist and are configured separately:
+
+| Feature | Values key | Description |
+|---------|------------|-------------|
+| Sidecar injection | `webhook.*` | MutatingWebhook that injects the sync-agent into labeled pods |
+| Push receiver | `webhookReceiver.*` | HTTP endpoint that accepts GitHub/GitLab push events for immediate sync |
+
+## Requirements
+
+Kubernetes: `>= 1.28.0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for scheduling the controller pod. |
+| agentImage | object | `{"repository":"ghcr.io/ia-eknorr/ignition-sync-agent","tag":""}` | Agent sidecar image injected into gateway pods by the webhook. |
+| agentImage.repository | string | `"ghcr.io/ia-eknorr/ignition-sync-agent"` | Image repository for the sync agent sidecar. |
+| agentImage.tag | string | `""` | Image tag. Defaults to the chart's appVersion if empty. |
+| certManager | object | `{"enabled":true}` | cert-manager integration for webhook TLS certificates. Requires cert-manager to be installed in the cluster. |
+| certManager.enabled | bool | `true` | Create a self-signed Issuer and Certificate for webhook TLS. Requires cert-manager to be installed in the cluster. |
+| fullnameOverride | string | `""` | Override the full release name used in resource names. |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/ia-eknorr/ignition-sync-operator","tag":""}` | Controller container image configuration. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy (Always, IfNotPresent, Never). |
+| image.repository | string | `"ghcr.io/ia-eknorr/ignition-sync-operator"` | Image repository for the controller manager. |
+| image.tag | string | `""` | Image tag. Defaults to the chart's appVersion if empty. |
+| imagePullSecrets | list | `[]` | Credentials for private container registries. Example:   imagePullSecrets:     - name: my-registry-secret |
+| leaderElection | object | `{"enabled":true}` | Leader election prevents multiple controller instances from reconciling simultaneously. Disable only for single-replica development setups. |
+| leaderElection.enabled | bool | `true` | Enable leader election for controller manager. |
+| metrics | object | `{"enabled":true,"service":{"port":8443,"type":"ClusterIP"}}` | Metrics endpoint configuration. The controller exposes Prometheus metrics over HTTPS on the metrics service port. |
+| metrics.enabled | bool | `true` | Enable the metrics Service. |
+| metrics.service.port | int | `8443` | Port the metrics service listens on. |
+| metrics.service.type | string | `"ClusterIP"` | Service type for the metrics endpoint. |
+| nameOverride | string | `""` | Override the chart name used in resource names. |
+| networkPolicy | object | `{"enabled":false}` | NetworkPolicy restricts ingress to the metrics port. Only allows traffic from namespaces labeled `metrics: enabled`. |
+| networkPolicy.enabled | bool | `false` | Create a NetworkPolicy for the controller. |
+| nodeSelector | object | `{}` | Node selector labels for scheduling the controller pod. Example:   nodeSelector:     kubernetes.io/os: linux |
+| replicaCount | int | `1` | Number of controller replicas. Only one replica holds the leader lock at a time; additional replicas provide fast failover. |
+| resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | CPU and memory resource requests/limits for the controller container. The controller runs git ls-remote (no clone) and watches CRs, so resource requirements are modest. |
+| serviceMonitor | object | `{"enabled":false}` | Prometheus ServiceMonitor for automatic scrape target discovery. Requires the prometheus-operator CRDs to be installed in the cluster. |
+| serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor resource. |
+| tolerations | list | `[]` | Tolerations for scheduling the controller pod on tainted nodes. |
+| webhook | object | `{"enabled":true,"port":9443}` | Mutating webhook for sidecar injection. When enabled, pods with annotation `ignition-sync.io/inject: "true"` in labeled namespaces get the sync-agent sidecar injected automatically. |
+| webhook.enabled | bool | `true` | Enable the MutatingWebhookConfiguration and webhook Service. |
+| webhook.port | int | `9443` | Webhook server port on the controller container. |
+| webhookReceiver | object | `{"hmac":{"secret":"","secretRef":{"key":"webhook-secret","name":""}},"port":9444}` | Git webhook receiver for push-event-driven sync. |
+| webhookReceiver.hmac | object | `{"secret":"","secretRef":{"key":"webhook-secret","name":""}}` | HMAC secret for validating webhook signatures (X-Hub-Signature-256). Provide either a literal value or a reference to an existing Secret. |
+| webhookReceiver.hmac.secret | string | `""` | HMAC secret value. Ignored if secretRef is set. |
+| webhookReceiver.hmac.secretRef | object | `{"key":"webhook-secret","name":""}` | Reference to an existing Secret containing the HMAC key. |
+| webhookReceiver.hmac.secretRef.key | string | `"webhook-secret"` | Key within the Secret. |
+| webhookReceiver.hmac.secretRef.name | string | `""` | Name of the Secret. |
+| webhookReceiver.port | int | `9444` | Port for the inbound git webhook receiver. Set to 0 to disable. |
+

--- a/charts/ignition-sync-operator/README.md.gotmpl
+++ b/charts/ignition-sync-operator/README.md.gotmpl
@@ -1,0 +1,46 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Prerequisites
+
+- Kubernetes >= 1.28
+- Helm 3
+- [cert-manager](https://cert-manager.io/) (when `certManager.enabled=true`)
+
+## Installation
+
+```bash
+helm install ignition-sync oci://ghcr.io/ia-eknorr/charts/ignition-sync-operator
+```
+
+See the post-install notes (`helm get notes <release>`) for next steps: creating
+secrets, applying CRs, labeling namespaces, and granting agent RBAC.
+
+## Architecture
+
+The operator has two components:
+
+- **Controller** — watches IgnitionSync and SyncProfile CRs, resolves git refs
+  via `ls-remote`, and manages metadata ConfigMaps.
+- **Agent sidecar** — injected into gateway pods via MutatingWebhook, clones the
+  repo and syncs files to the Ignition data directory.
+
+Two webhook-like features exist and are configured separately:
+
+| Feature | Values key | Description |
+|---------|------------|-------------|
+| Sidecar injection | `webhook.*` | MutatingWebhook that injects the sync-agent into labeled pods |
+| Push receiver | `webhookReceiver.*` | HTTP endpoint that accepts GitHub/GitLab push events for immediate sync |
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "chart.maintainersSection" . }}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@ is limited.
 - M1: Webhook receiver HMAC signature validation (currently accepts all requests)
 - M2: Agent Dockerfile health endpoint (liveness/readiness for the sidecar)
 - M3: Structured logging alignment (controller uses `logr`, agent should match)
-- M4: Helm chart values documentation via helm-docs
+- ~~M4: Helm chart values documentation via helm-docs~~ — done (PR #27)
 - M5: Integration test for full sync cycle (controller + agent in kind)
 
 ## v0.2.0 — Reliability


### PR DESCRIPTION
### 📖 Background

M4 on the v0.1.0 roadmap: the Helm chart has well-annotated `values.yaml` (`# --` comments on every key) but no chart-level README for users browsing the chart on GitHub or ArtifactHub.

### ⚙️ Changes

- Add `README.md.gotmpl` template with badges, prerequisites, install instructions, architecture overview, and the auto-generated values table
- Add `make helm-docs` target using the same `go-install-tool` pattern as other Makefile dependencies (helm-docs v1.14.2)
- Add `helm-docs` CI job to `lint.yml` that regenerates the README and fails if it drifts from what's committed
- Generate the initial `charts/ignition-sync-operator/README.md` with all 38 parameters
- Mark M4 done in `docs/roadmap.md`

### 📝 Reviewer Notes

The generated `README.md` should not be hand-edited — edit `values.yaml` comments or `README.md.gotmpl` instead, then run `make helm-docs`.

### ☑️ Testing Notes

- `make helm-docs` generates the README without errors
- `helm-docs --chart-search-root charts && git diff --exit-code charts/` shows no drift
- `helm template test charts/ignition-sync-operator/` renders cleanly
- `make lint` passes