### PR TITLE
restore NOTES.txt lost during rename

### DIFF
--- a/charts/stoker-operator/templates/NOTES.txt
+++ b/charts/stoker-operator/templates/NOTES.txt
@@ -1,0 +1,71 @@
+🔥 Stoker has been installed in namespace {{ .Release.Namespace }}.
+
+== Next Steps ==
+
+1. Create secrets for git authentication and gateway API access:
+
+    kubectl create secret generic git-creds -n <namespace> \
+      --from-literal=token=<your-git-token>
+
+    kubectl create secret generic gw-api-key -n <namespace> \
+      --from-literal=apiKey=<token-name>:<token-secret>
+
+2. Apply a Stoker CR to define the git repository:
+
+    apiVersion: stoker.io/v1alpha1
+    kind: Stoker
+    metadata:
+      name: my-sync
+    spec:
+      git:
+        repo: "https://github.com/your-org/ignition-config.git"
+        ref: "main"
+        auth:
+          token:
+            secretRef:
+              name: git-creds
+              key: token
+      gateway:
+        apiKeySecretRef:
+          name: gw-api-key
+          key: apiKey
+
+3. Apply a SyncProfile to define file mappings:
+
+    apiVersion: stoker.io/v1alpha1
+    kind: SyncProfile
+    metadata:
+      name: my-profile
+    spec:
+      mappings:
+        - source: "projects/"
+          destination: "projects/"
+          type: dir
+          required: true
+      syncPeriod: 30
+
+4. Label the namespace for sidecar injection:
+
+    kubectl label namespace <namespace> stoker.io/injection=enabled
+
+5. Grant the agent RBAC in each namespace where gateways run:
+
+    kubectl create rolebinding stoker-agent -n <namespace> \
+      --clusterrole={{ include "stoker-operator.fullname" . }}-agent \
+      --serviceaccount=<namespace>:<gateway-service-account>
+
+6. Add the injection annotation to your Ignition gateway pod template:
+
+    podAnnotations:
+      stoker.io/inject: "true"
+      stoker.io/sync-profile: "my-profile"
+
+{{- if and .Values.webhook.enabled .Values.certManager.enabled }}
+
+== cert-manager ==
+
+TLS certificates for sidecar injection are managed by cert-manager.
+Ensure cert-manager is installed: https://cert-manager.io/docs/installation/
+{{- end }}
+
+For documentation, see: https://github.com/ia-eknorr/stoker-operator


### PR DESCRIPTION
## Background
The Helm chart NOTES.txt was dropped when the chart directory was renamed from `charts/ignition-sync-operator/` to `charts/stoker-operator/` in PR #29.

## Changes
- Restore `charts/stoker-operator/templates/NOTES.txt` with updated Stoker branding