### PR TITLE
fix release matrix to cross-product images and platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,19 +15,20 @@ jobs:
   build-images:
     strategy:
       matrix:
+        image_name: [stoker-operator, stoker-agent]
+        arch: [amd64, arm64]
         include:
-          - name: controller
+          - image_name: stoker-operator
             file: Dockerfile
-            image_name: stoker-operator
-          - name: agent
+          - image_name: stoker-agent
             file: Dockerfile.agent
-            image_name: stoker-agent
-        platform:
-          - runner: ubuntu-latest
-            arch: linux/amd64
-          - runner: ubuntu-24.04-arm
-            arch: linux/arm64
-    runs-on: ${{ matrix.platform.runner }}
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -53,10 +54,10 @@ jobs:
         with:
           context: .
           file: ${{ matrix.file }}
-          platforms: ${{ matrix.platform.arch }}
+          platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image_name }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image_name }}:buildcache-${{ matrix.platform.arch == 'linux/amd64' && 'amd64' || 'arm64' }}
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image_name }}:buildcache-${{ matrix.platform.arch == 'linux/amd64' && 'amd64' || 'arm64' }},mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image_name }}:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image_name }}:buildcache-${{ matrix.arch }},mode=max
 
       - name: Export digest
         run: |
@@ -67,7 +68,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digest-${{ matrix.image_name }}-${{ matrix.platform.arch == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: digest-${{ matrix.image_name }}-${{ matrix.arch }}
           path: /tmp/digests/${{ matrix.image_name }}
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
## Background
The v0.1.0 release build produced only 2 jobs instead of 4 — the `include` + `platform` matrix didn't cross-product. The merge-manifests step failed because per-image digest artifacts were never uploaded.

## Changes
- Restructure matrix to use flat keys (`image_name` × `arch`) for proper 2×2 cross-product
- Use `include` only to add properties (file, runner, platform) to matching entries
- Simplify cache and artifact name references to use `matrix.arch` directly