### PR TITLE
fix status lookup when gateway-name annotation is unset

### DIFF
--- a/charts/stoker-operator/templates/NOTES.txt
+++ b/charts/stoker-operator/templates/NOTES.txt
@@ -54,11 +54,13 @@
       --clusterrole={{ include "stoker-operator.fullname" . }}-agent \
       --serviceaccount=<namespace>:<gateway-service-account>
 
-6. Add the injection annotation to your Ignition gateway pod template:
+6. Add the injection annotations to your Ignition gateway pod template:
 
     podAnnotations:
       stoker.io/inject: "true"
+      stoker.io/cr-name: "my-sync"
       stoker.io/sync-profile: "my-profile"
+      # stoker.io/gateway-name: "my-gw"  # optional — defaults to app.kubernetes.io/name label or pod name
 
 {{- if and .Values.webhook.enabled .Values.certManager.enabled }}
 

--- a/internal/controller/gateway_discovery.go
+++ b/internal/controller/gateway_discovery.go
@@ -126,9 +126,14 @@ func (r *StokerReconciler) collectGatewayStatus(ctx context.Context, stk *stoker
 		return gateways
 	}
 
-	// Enrich each gateway with its status
+	// Enrich each gateway with its status.
+	// The agent writes status keyed by its GATEWAY_NAME env, which defaults to the
+	// pod name when unset. Look up by PodName first, then fall back to Name.
 	for i := range gateways {
-		statusJSON, ok := cm.Data[gateways[i].Name]
+		statusJSON, ok := cm.Data[gateways[i].PodName]
+		if !ok {
+			statusJSON, ok = cm.Data[gateways[i].Name]
+		}
 		if !ok || statusJSON == "" {
 			continue
 		}


### PR DESCRIPTION
### 📖 Background

The controller resolves gateway names using a 3-tier fallback: `stoker.io/gateway-name` annotation > `app.kubernetes.io/name` label > pod name. The agent writes status to the ConfigMap keyed by its `GATEWAY_NAME` env, which defaults to the pod name when unset. When the `stoker.io/gateway-name` annotation was not set (it's optional), the controller looked up status by the label-derived name (e.g. `ignition`) while the ConfigMap key was the pod name (e.g. `ignition-gateway-0`). Status was never matched, so gateways stayed `Pending` forever.

### ⚙️ Changes

- `collectGatewayStatus` now looks up by `PodName` first, then falls back to `Name`
- Updated NOTES.txt to include the missing `cr-name` annotation and document `gateway-name` as optional

### 📝 Reviewer Notes

The `stoker.io/gateway-name` annotation is only needed to override the display name or when using `{{.GatewayName}}` templates in SyncProfile mappings. Without it, everything works correctly — the controller matches status by pod name.

### ☑️ Testing Notes

- Deploy a gateway without `stoker.io/gateway-name` annotation
- Verify `kubectl get stokers` shows `SYNCED=True` and `1/1 gateways synced`
- Verified end-to-end on kind-dev with the quickstart guide