### PR TITLE
update quickstart, add release badge and Ignition chart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p align="center">
   <a href="https://github.com/ia-eknorr/stoker-operator/actions/workflows/lint.yml"><img src="https://github.com/ia-eknorr/stoker-operator/actions/workflows/lint.yml/badge.svg" alt="Lint"></a>
   <a href="https://github.com/ia-eknorr/stoker-operator/actions/workflows/test.yml"><img src="https://github.com/ia-eknorr/stoker-operator/actions/workflows/test.yml/badge.svg" alt="Test"></a>
+  <a href="https://github.com/ia-eknorr/stoker-operator/releases/latest"><img src="https://img.shields.io/github/v/release/ia-eknorr/stoker-operator" alt="Release"></a>
   <a href="https://github.com/ia-eknorr/stoker-operator/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"></a>
 </p>
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -88,6 +88,10 @@ const config: Config = {
               label: "Helm Chart",
               href: "https://github.com/ia-eknorr/stoker-operator/tree/main/charts/stoker-operator",
             },
+            {
+              label: "Ignition Helm Chart",
+              href: "https://charts.ia.io",
+            },
           ],
         },
       ],


### PR DESCRIPTION
### 📖 Background
The Docusaurus quickstart was a simplified version written during the initial docs site setup. The official quickstart on `docs/quickstart-guide` has since been tested end-to-end and refined over several iterations. The README also lacked a version badge, and the footer was missing a link to the Ignition Helm chart.

### ⚙️ Changes
- Replace Docusaurus quickstart with the official tested version (converted GitHub alert syntax to Docusaurus admonitions, added missing verification sections)
- Add dynamic release version badge to README via shields.io (`github/v/release`)
- Add Ignition Helm chart link (`charts.ia.io`) to docs footer under "More"

### 📝 Reviewer Notes
The quickstart diff looks large but is mostly structural: removed duplicate YAML blocks (kept only the `cat <<EOF | kubectl apply` form), added `:::note`/`:::tip` admonitions, and added the extra verification subsections (events, describe, status ConfigMap) from the tested guide.

### ☑️ Testing Notes
- `cd docs && npm run build` passes cleanly
- Verify the release badge renders at `img.shields.io/github/v/release/ia-eknorr/stoker-operator`