### PR TITLE
add devcontainer with Go toolchain and Claude Code support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+FROM mcr.microsoft.com/devcontainers/go:1.25
+
+# ---------- versions (keep in sync with Makefile) ----------
+ARG KUSTOMIZE_VERSION=v5.7.1
+ARG CONTROLLER_TOOLS_VERSION=v0.20.0
+ARG GOLANGCI_LINT_VERSION=v2.7.2
+ARG HELM_DOCS_VERSION=v1.14.2
+
+# ---------- system packages ----------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------- system binaries (root) ----------
+ARG TARGETARCH
+RUN ARCH=$(dpkg --print-architecture) \
+    # kubectl
+    && curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl" \
+       -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl \
+    # kind
+    && curl -fsSL "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}" \
+       -o /usr/local/bin/kind && chmod +x /usr/local/bin/kind \
+    # helm
+    && curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# ---------- Go tools (vscode user) ----------
+USER vscode
+ENV GOPATH=/home/vscode/go
+ENV PATH="${GOPATH}/bin:${PATH}"
+
+RUN go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION} \
+    && go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_TOOLS_VERSION} \
+    && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION} \
+    && go install github.com/norwoodj/helm-docs/cmd/helm-docs@${HELM_DOCS_VERSION} \
+    && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
+    && go clean -cache -modcache
+
+USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+  "name": "Stoker Operator",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/node:1": { "version": "22" }
+  },
+  // Creates ~/.claude on host if missing so the bind mount never fails.
+  // Remove the initializeCommand and the ~/.claude mount below if you don't use Claude Code.
+  "initializeCommand": "mkdir -p ${HOME}/.claude",
+  "mounts": [
+    "source=stoker-gomodcache,target=/home/vscode/go/pkg/mod,type=volume",
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
+  ],
+  "forwardPorts": [8081, 9443, 9444, 3000],
+  "portsAttributes": {
+    "8081":  { "label": "Health probe" },
+    "9443":  { "label": "Admission webhook" },
+    "9444":  { "label": "Webhook receiver" },
+    "3000":  { "label": "Docusaurus" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "redhat.vscode-yaml",
+        "Tim-Koehler.helm-intellisense"
+      ],
+      "settings": {
+        "go.lintTool": "golangci-lint",
+        "go.toolsManagement.autoUpdate": false
+      }
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Downloading Go modules..."
+go mod download
+
+echo "==> Configuring git hooks..."
+make setup
+
+echo "==> Installing Docusaurus dependencies..."
+if [ -f docs/package-lock.json ]; then
+  (cd docs && npm ci)
+elif [ -f docs/package.json ]; then
+  (cd docs && npm install)
+fi
+
+echo "==> Installing Claude Code..."
+npm install -g @anthropic-ai/claude-code 2>/dev/null || echo "    (skipped — npm install failed, install manually if needed)"
+
+echo ""
+echo "==> Tool versions:"
+go version
+kubectl version --client --short 2>/dev/null || kubectl version --client
+kind version
+helm version --short
+controller-gen --version
+golangci-lint version --short 2>/dev/null || golangci-lint version
+kustomize version
+helm-docs --version 2>/dev/null || true
+echo ""
+echo "==> Ready! Create a kind cluster with: kind create cluster --name dev"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,36 @@ make setup    # configures git hooks
 
 `make setup` points git to `.githooks/`, which includes a **pre-commit hook** that runs golangci-lint on staged Go files.
 
+## Devcontainer
+
+The fastest way to get a working environment is the included devcontainer, which ships with all prerequisites pre-installed (Go, kubectl, kind, helm, controller-gen, golangci-lint, etc.).
+
+### Opening the devcontainer
+
+1. Install the **Dev Containers** extension in VS Code.
+2. Open the repo and run **Dev Containers: Reopen in Container** from the command palette.
+3. The `postCreateCommand` runs automatically — it downloads Go modules, configures git hooks, and installs Docusaurus dependencies.
+
+### Shell customization (dotfiles)
+
+The devcontainer ships with a vanilla shell. To bring your own config (oh-my-zsh, p10k, starship, etc.), configure a **dotfiles repository** in VS Code:
+
+```
+Settings → Dev Containers → Dotfiles: Repository
+```
+
+VS Code will clone and install your dotfiles into each new container. See the [VS Code docs](https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories) for details.
+
+### Creating a kind cluster
+
+The devcontainer has Docker socket access, so kind works out of the box:
+
+```bash
+kind create cluster --name dev
+```
+
+This creates a cluster you can immediately use with `kubectl`, `make run`, or `make functional-test`.
+
 ## Development Loop
 
 ```bash


### PR DESCRIPTION
### 📖 Background

Contributors need a reproducible dev environment with all project tools pre-installed. This avoids the "works on my machine" problem and gets new contributors building in minutes instead of chasing tool versions.

### ⚙️ Changes

- **`.devcontainer/Dockerfile`** — Custom image on `go:1.25` with kubectl, kind, helm (system), and controller-gen, kustomize, golangci-lint, helm-docs, setup-envtest (Go tools). Versions pinned to match the Makefile.
- **`.devcontainer/devcontainer.json`** — Docker socket feature for kind, Node 22 for Docusaurus, named volume for Go module cache, port forwarding (health/webhook/docs), VS Code extensions and settings. Optional bind mount for `~/.claude` config.
- **`.devcontainer/post-create.sh`** — Runs `go mod download`, `make setup`, `npm ci` for docs, installs Claude Code, prints tool versions.
- **`CONTRIBUTING.md`** — New "Devcontainer" section with setup instructions, dotfiles config, and kind cluster creation.

### 📝 Reviewer Notes

- The `~/.claude` bind mount uses `initializeCommand` to `mkdir -p` on the host so it never fails — harmless empty dir if Claude Code isn't installed. Remove the mount + initializeCommand if unwanted.
- `go clean -cache -modcache` after tool installs keeps the image lean.
- Tool versions are ARGs matching the Makefile: kustomize v5.7.1, controller-gen v0.20.0, golangci-lint v2.7.2, helm-docs v1.14.2.

### ☑️ Testing Notes

1. `Dev Containers: Rebuild Container` from VS Code command palette
2. Verify tools: `go version`, `kubectl version --client`, `kind version`, `helm version`, `controller-gen --version`, `golangci-lint version`
3. Verify Docker socket: `docker ps`
4. Create kind cluster: `kind create cluster --name dev`
5. Run project: `make build && make test && make lint`
6. Verify docs: `cd docs && npm start` → opens on port 3000