### PR TITLE
consolidate e2e tests into single job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,17 +14,9 @@ on:
 
 jobs:
   e2e:
-    name: Chainsaw E2E (${{ matrix.group }})
+    name: Chainsaw E2E
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - group: core
-            suites: controller-core syncprofile webhook-receiver
-          - group: integration
-            suites: gateway-discovery webhook-injection
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'pull_request' ||
@@ -89,11 +81,13 @@ jobs:
 
       - name: Run Chainsaw tests
         run: |
-          args=""
-          for suite in ${{ matrix.suites }}; do
-            args="$args --test-dir test/e2e/$suite"
-          done
-          chainsaw test $args --config test/e2e/.chainsaw.yaml
+          chainsaw test \
+            --test-dir test/e2e/controller-core \
+            --test-dir test/e2e/syncprofile \
+            --test-dir test/e2e/webhook-receiver \
+            --test-dir test/e2e/gateway-discovery \
+            --test-dir test/e2e/webhook-injection \
+            --config test/e2e/.chainsaw.yaml
 
       - name: Collect logs on failure
         if: failure()


### PR DESCRIPTION
### 📖 Background

The 2-job e2e matrix duplicates the entire cluster setup (kind, Helm, image builds, operator deploy) on separate runners. This has been causing frequent failures from git server pod timeouts due to resource contention during bootstrapping.

### ⚙️ Changes

- Remove 2-job matrix strategy (`core` / `integration` groups)
- Run all 5 test suites sequentially in a single job against one cluster

### ☑️ Testing Notes

This PR itself will exercise the new single-job workflow.