### PR TITLE
fix dry-run mode to report Synced status on success

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -427,12 +427,13 @@ func (a *Agent) syncOnce(ctx context.Context, commit, ref string, isInitial bool
 
 	// Determine status: only "Synced" if scan succeeded (both 200).
 	// Initial sync reports "Pending" since gateway isn't running yet to validate.
+	// Dry-run is always "Synced" on success — staging files IS the success state.
 	syncStatus := stokertypes.SyncStatusSynced
 	var errorMsg string
-	if isInitial {
+	if isDryRun {
+		// dry-run: no scan needed, staging files successfully is the success state
+	} else if isInitial {
 		syncStatus = stokertypes.SyncStatusPending
-	} else if isDryRun {
-		// dry-run: no scan, report Synced (files validated via diff)
 	} else if scanResultStr == "" || strings.Contains(scanResultStr, "error") {
 		syncStatus = stokertypes.SyncStatusError
 		errorMsg = scanResultStr


### PR DESCRIPTION
### 📖 Background

During manual testing (Test 5), a GatewaySync with `dryRun: true` never reached Ready=True. The agent reported `Pending` on initial sync and never transitioned to `Synced` because the scan API is skipped in dry-run mode.

### ⚙️ Changes

- Reordered status determination in `syncOnce()` so `isDryRun` is checked before `isInitial`
- When dry-run mode is active and file operations succeeded, status is `Synced` (staging files IS the success state)

### ☑️ Testing Notes

Fixes #52

Rerun manual Test 5 (dry-run mode): GS should show `1/1 gateways synced` and `READY=True` with dry-run enabled.