### PR TITLE
fix webhook to write discovered cr-name annotation to pod

### DIFF
--- a/internal/webhook/inject.go
+++ b/internal/webhook/inject.go
@@ -75,6 +75,14 @@ func (p *PodInjector) Handle(ctx context.Context, req admission.Request) admissi
 		return admission.Denied(err.Error())
 	}
 
+	// Write discovered CR name back to pod so the controller can find it
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	if pod.Annotations[stokertypes.AnnotationCRName] == "" {
+		pod.Annotations[stokertypes.AnnotationCRName] = crName
+	}
+
 	// Fetch GatewaySync CR
 	var gs stokerv1alpha1.GatewaySync
 	key := client.ObjectKey{Name: crName, Namespace: req.Namespace}


### PR DESCRIPTION
### 📖 Background

During manual testing (Test 17), the auto-discover feature was broken. When a pod had `stoker.io/inject: "true"` but no `stoker.io/cr-name`, the webhook discovered the CR and injected the sidecar, but never wrote the annotation back. The agent lacked `CR_NAME` and gateway discovery couldn't find the pod.

### ⚙️ Changes

- After `resolveCRName()` returns, write `stoker.io/cr-name` annotation to pod if not already set
- Updated test to verify the annotation appears in the webhook response patches

### ☑️ Testing Notes

Fixes #55

Rerun manual Test 17 (auto-discover): Deploy gateway with only `stoker.io/inject: "true"` and `stoker.io/profile`, no `stoker.io/cr-name`. GS should discover the gateway and reach Ready=True.