### PR TITLE
make namespace injection label optional (default off)

### DIFF
--- a/charts/stoker-operator/README.md.gotmpl
+++ b/charts/stoker-operator/README.md.gotmpl
@@ -21,7 +21,7 @@ helm install stoker oci://ghcr.io/ia-eknorr/charts/stoker-operator
 ```
 
 See the post-install notes (`helm get notes <release>`) for next steps: creating
-secrets, applying CRs, labeling namespaces, and granting agent RBAC.
+secrets, applying CRs, and granting agent RBAC.
 
 ## Architecture
 
@@ -36,7 +36,7 @@ Two webhook-like features exist and are configured separately:
 
 | Feature | Values key | Description |
 |---------|------------|-------------|
-| Sidecar injection | `webhook.*` | MutatingWebhook that injects the stoker-agent into labeled pods |
+| Sidecar injection | `webhook.*` | MutatingWebhook that injects the stoker-agent into annotated pods |
 | Push receiver | `webhookReceiver.*` | HTTP endpoint that accepts GitHub/GitLab push events for immediate sync |
 
 {{ template "chart.requirementsSection" . }}

--- a/charts/stoker-operator/templates/NOTES.txt
+++ b/charts/stoker-operator/templates/NOTES.txt
@@ -39,9 +39,15 @@
                 required: true
             syncPeriod: 30
 
+{{- if .Values.webhook.namespaceSelector.requireLabel }}
 3. Label the namespace for sidecar injection:
 
     kubectl label namespace <namespace> stoker.io/injection=enabled
+{{- else }}
+3. Sidecar injection is enabled cluster-wide by default.
+   Pods with annotation stoker.io/inject: "true" will be injected in any namespace.
+   To restrict injection to specific namespaces, set webhook.namespaceSelector.requireLabel=true.
+{{- end }}
 
 4. Grant the agent RBAC in each namespace where gateways run:
 

--- a/charts/stoker-operator/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/stoker-operator/templates/mutatingwebhookconfiguration.yaml
@@ -21,10 +21,17 @@ webhooks:
     matchPolicy: Equivalent
     reinvocationPolicy: IfNeeded
     namespaceSelector:
+{{- if .Values.webhook.namespaceSelector.requireLabel }}
       matchExpressions:
         - key: stoker.io/injection
           operator: In
           values: ["enabled"]
+{{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: ["kube-system", "kube-node-lease"]
+{{- end }}
     rules:
       - apiGroups: [""]
         apiVersions: ["v1"]

--- a/charts/stoker-operator/values.yaml
+++ b/charts/stoker-operator/values.yaml
@@ -70,13 +70,19 @@ networkPolicy:
   enabled: false
 
 # -- Mutating webhook for sidecar injection. When enabled, pods with annotation
-# `stoker.io/inject: "true"` in labeled namespaces get the stoker-agent
-# sidecar injected automatically.
+# `stoker.io/inject: "true"` get the stoker-agent sidecar injected automatically.
+# By default, injection works in all namespaces except kube-system and kube-node-lease.
 webhook:
   # -- Enable the MutatingWebhookConfiguration and webhook Service.
   enabled: true
   # -- Webhook server port on the controller container.
   port: 9443
+  namespaceSelector:
+    # -- Require the stoker.io/injection=enabled label on namespaces
+    # for sidecar injection. When false (default), the webhook intercepts
+    # pod creates in all namespaces except kube-system and kube-node-lease.
+    # Enable for regulated environments that require explicit namespace opt-in.
+    requireLabel: false
 
 # -- cert-manager integration for webhook TLS certificates.
 # Requires cert-manager to be installed in the cluster.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -38,7 +38,16 @@ You should see a `controller-manager` pod in `Running` state.
 
 ## Enable sidecar injection
 
-Label any namespace where you want the webhook to inject agent sidecars:
+Sidecar injection is enabled by default in all namespaces (except `kube-system` and `kube-node-lease`). Any pod with annotation `stoker.io/inject: "true"` will receive the agent sidecar — no namespace label is needed.
+
+For regulated environments that require explicit namespace opt-in (e.g., IEC 62443 zone boundaries), enable the namespace label requirement:
+
+```bash
+helm upgrade stoker oci://ghcr.io/ia-eknorr/charts/stoker-operator \
+  -n stoker-system --set webhook.namespaceSelector.requireLabel=true
+```
+
+Then label each namespace where injection should be allowed:
 
 ```bash
 kubectl label namespace <your-namespace> stoker.io/injection=enabled

--- a/docs/docs/overview/architecture.md
+++ b/docs/docs/overview/architecture.md
@@ -43,10 +43,11 @@ The controller uses a custom predicate that triggers reconciliation on spec gene
 
 ### Mutating webhook
 
-The webhook intercepts pod creation and injects the agent as a **native sidecar** — an init container with `restartPolicy: Always` (requires Kubernetes 1.28+). Injection requires two conditions:
+The webhook intercepts pod creation and injects the agent as a **native sidecar** — an init container with `restartPolicy: Always` (requires Kubernetes 1.28+). Injection requires one condition:
 
-1. **Namespace label:** `stoker.io/injection=enabled`
-2. **Pod annotation:** `stoker.io/inject: "true"`
+1. **Pod annotation:** `stoker.io/inject: "true"`
+
+Optionally, the `stoker.io/injection=enabled` namespace label can be required by setting `webhook.namespaceSelector.requireLabel=true` in the Helm values. This is useful for regulated environments that need explicit namespace opt-in.
 
 The agent image is resolved in three tiers: pod annotation `stoker.io/agent-image` > CR field `spec.agent.image` > environment variable `DEFAULT_AGENT_IMAGE`.
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: Quickstart
-description: Get a single Ignition gateway syncing projects from Git in 7 steps.
+description: Get a single Ignition gateway syncing projects from Git in 6 steps.
 ---
 
 # Quickstart
 
-Get a single Ignition gateway syncing projects from Git in 7 steps.
+Get a single Ignition gateway syncing projects from Git in 6 steps.
 
 ## Prerequisites
 
@@ -46,22 +46,12 @@ kubectl get pods -n stoker-system
 
 You should see a `controller-manager` pod in `Running` state.
 
-## 3. Prepare a namespace
+## 3. Create secrets
 
-Create a namespace and label it for sidecar injection:
+Create a namespace and a secret so the agent can authenticate with the gateway's scan API. The example repository includes a pre-configured API token resource:
 
 ```bash
 kubectl create namespace quickstart
-kubectl label namespace quickstart stoker.io/injection=enabled
-```
-
-The `stoker.io/injection=enabled` label tells the mutating webhook to watch for annotated pods in this namespace.
-
-## 4. Create secrets
-
-The example repository includes a pre-configured API token resource. Create a matching secret so the agent can authenticate with the gateway's scan API:
-
-```bash
 kubectl create secret generic gw-api-key -n quickstart \
   --from-literal=apiKey="ignition-api-key:CYCSdRgW6MHYkeIXhH-BMqo1oaqfTdFi8tXvHJeCKmY"
 ```
@@ -72,7 +62,7 @@ This API key belongs to the public example repository and carries no security ri
 
 No git credentials are needed since we're using a public repository.
 
-## 5. Create a GatewaySync CR
+## 4. Create a GatewaySync CR
 
 The GatewaySync CR defines the git repository and sync profiles. We set `gateway.port` and `gateway.tls` to match the default Ignition Helm chart (HTTP on 8088):
 
@@ -116,7 +106,7 @@ kubectl get gatewaysyncs -n quickstart
 
 The `REF` column should show `main` and `COMMIT` should show a short hash. `READY` will be `False` until a gateway is deployed and synced.
 
-## 6. Grant agent RBAC
+## 5. Grant agent RBAC
 
 The agent sidecar needs permission to read GatewaySync CRs and write status ConfigMaps. The Helm chart installs a ClusterRole for this — bind it to the gateway's service account:
 
@@ -130,7 +120,7 @@ kubectl create rolebinding stoker-agent -n quickstart \
 The service account name (`ignition`) matches the default created by the Ignition Helm chart. If your gateway uses a different service account, substitute it here.
 :::
 
-## 7. Deploy an Ignition gateway
+## 6. Deploy an Ignition gateway
 
 Install using the [official Ignition Helm chart](https://charts.ia.io) with Stoker annotations.
 
@@ -160,7 +150,7 @@ podAnnotations:
 
 ```bash
 helm upgrade --install ignition inductiveautomation/ignition \
-  -n quickstart -f ignition-values.yaml
+  -n quickstart --create-namespace -f ignition-values.yaml
 ```
 
 The key annotations:

--- a/docs/docs/reference/annotations.md
+++ b/docs/docs/reference/annotations.md
@@ -37,13 +37,13 @@ Use `--set-string` (not `--set`) when passing annotation values through Helm to 
 
 | Label | Value | Description |
 |-------|-------|-------------|
-| `stoker.io/injection` | `enabled` | Required on any namespace where the webhook should inject agent sidecars |
+| `stoker.io/injection` | `enabled` | Optional — only needed when `webhook.namespaceSelector.requireLabel=true`. Marks the namespace for sidecar injection. |
 
 ```bash
 kubectl label namespace my-namespace stoker.io/injection=enabled
 ```
 
-The mutating webhook uses a `namespaceSelector` that matches this label. Pods in unlabeled namespaces are never intercepted.
+By default, the webhook intercepts pod creates in all namespaces except `kube-system` and `kube-node-lease`. The namespace label is only required when `webhook.namespaceSelector.requireLabel` is set to `true` in the Helm values.
 
 ## CR annotations (set by webhook receiver)
 

--- a/docs/docs/reference/helm-values.md
+++ b/docs/docs/reference/helm-values.md
@@ -58,8 +58,9 @@ helm install stoker oci://ghcr.io/ia-eknorr/charts/stoker-operator \
 |-----|------|---------|-------------|
 | `webhook.enabled` | bool | `true` | Enable the MutatingWebhookConfiguration. |
 | `webhook.port` | int | `9443` | Webhook server port on the controller container. |
+| `webhook.namespaceSelector.requireLabel` | bool | `false` | Require `stoker.io/injection=enabled` label on namespaces for injection. When false, injection works in all namespaces except `kube-system` and `kube-node-lease`. |
 
-The webhook injects the agent sidecar into pods with annotation `stoker.io/inject: "true"` in namespaces labeled `stoker.io/injection=enabled`.
+The webhook injects the agent sidecar into pods with annotation `stoker.io/inject: "true"`. By default, injection works in all namespaces except `kube-system` and `kube-node-lease`. Set `webhook.namespaceSelector.requireLabel=true` to require the `stoker.io/injection=enabled` namespace label.
 
 ### Push Receiver (Webhook)
 

--- a/docs/docs/reference/troubleshooting.md
+++ b/docs/docs/reference/troubleshooting.md
@@ -14,10 +14,11 @@ description: Common issues, debug commands, and FAQ.
 
 **Checklist:**
 
-1. **Namespace label** — ensure the namespace has `stoker.io/injection=enabled`:
+1. **Namespace label** — if `webhook.namespaceSelector.requireLabel=true` is set, ensure the namespace has `stoker.io/injection=enabled`:
    ```bash
    kubectl get namespace <ns> --show-labels
    ```
+   With the default configuration, no namespace label is needed — injection works in all namespaces except `kube-system` and `kube-node-lease`.
 2. **Pod annotation** — ensure the pod has `stoker.io/inject: "true"` (must be a string, not a boolean):
    ```bash
    kubectl get pod <pod> -n <ns> -o jsonpath='{.metadata.annotations}'

--- a/test/e2e/.chainsaw.yaml
+++ b/test/e2e/.chainsaw.yaml
@@ -18,5 +18,4 @@ spec:
   namespace:
     template:
       metadata:
-        labels:
-          stoker.io/injection: "enabled"
+        labels: {}


### PR DESCRIPTION
### 📖 Background

The mutating webhook previously required namespaces to be labeled `stoker.io/injection=enabled` before sidecar injection would work. This was the #1 setup friction point — users forget the label and the pod launches without the sidecar with no indication of what went wrong. Pod-annotation-only injection is the proven pattern across the CNCF landscape (Vault, Dapr).

### ⚙️ Changes

- Added `webhook.namespaceSelector.requireLabel` Helm value (default `false`)
- When `false`: webhook uses `kubernetes.io/metadata.name NotIn [kube-system, kube-node-lease]` — injection works in all user namespaces
- When `true`: preserves existing behavior requiring `stoker.io/injection=enabled` namespace label
- Updated NOTES.txt with conditional namespace label step
- Updated all documentation (quickstart, installation, architecture, annotations, helm-values, troubleshooting) to reflect the new default
- Removed `stoker.io/injection` label from e2e chainsaw namespace template

### 📝 Reviewer Notes

No Go code changes — `internal/webhook/inject.go` never checked the namespace label (that was handled by the K8s API server via the webhook's `namespaceSelector`). The `LabelNamespaceInjection` constant in `pkg/types/annotations.go` is kept since it's used in `requireLabel` mode.

`failurePolicy: Ignore` on the webhook ensures that broadening the selector to all namespaces has zero risk — any webhook failure silently passes the pod through uninjected.

### ☑️ Testing Notes

Verified on kind-dev cluster:
- **Default mode** (unlabeled namespace + inject annotation) → sidecar injected ✓
- **requireLabel=true** (unlabeled namespace) → no injection ✓
- **requireLabel=true** (labeled namespace) → sidecar injected ✓
- `make build`, `make lint`, `make test` all pass
- `helm template` renders correctly for both modes