### PR TITLE
clean up CI workflow names and e2e trigger strategy

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,13 +1,8 @@
-name: E2E Tests
+name: E2E
 
 on:
   push:
     branches: [main]
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - 'LICENSE'
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -19,7 +14,6 @@ jobs:
     timeout-minutes: 30
     if: >-
       github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'issue_comment' &&

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit Test
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Rename workflow names for consistency: `E2E Tests` → `E2E`, `Tests` → `Unit Test`
- Rename `test.yml` → `unit-test.yml` to match its purpose
- Remove automatic e2e trigger on PRs (~13 min runs); use `/test-e2e` comment trigger instead
- E2E still runs automatically on push to main and via workflow_dispatch

## PR checks after this change
| File | Workflow | Job |
|---|---|---|
| `lint.yml` | Lint | `lint`, `verify-codegen`, `helm-docs` |
| `unit-test.yml` | Unit Test | `unit-tests` |
| `e2e.yml` | E2E | `e2e-tests` (main push / `/test-e2e` / dispatch only) |