### PR TITLE
improve quickstart: move cert-manager to prereqs, add repo context

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -58,7 +58,7 @@ kubectl create secret generic gw-api-key -n quickstart \
 ```
 
 :::warning
-This API key is for the example repository only. Never reuse example credentials — generate unique API tokens for each gateway in your own deployments.
+This API key is for the example repository only. Never reuse example credentials — [generate unique API tokens](https://www.docs.inductiveautomation.com/docs/8.3/platform/security/api-keys#using-api-keys) for each gateway in your own deployments.
 :::
 
 No git credentials are needed since we're using a public repository.


### PR DESCRIPTION
### 📖 Background

The quickstart had cert-manager as "Step 1" when it's really cluster infrastructure, not Stoker-specific. The example repo was referenced without introduction, and the API key note was verbose.

### ⚙️ Changes

- Move cert-manager from Step 1 into Prerequisites section with inline install instructions
- Add example repo introduction before the secrets step explaining what `ia-eknorr/test-ignition-project` contains
- Replace verbose `:::note` with a concise `:::warning` for the API key, link to [Ignition API key docs](https://www.docs.inductiveautomation.com/docs/8.3/platform/security/api-keys#using-api-keys)
- Renumber steps from 5 → 4

### 📝 Reviewer Notes

Docs-only change, no code impact.

### ☑️ Testing Notes

- Read the quickstart top-to-bottom for flow
- Verify step numbers are sequential (1-4)
- Verify the example repo link resolves: https://github.com/ia-eknorr/test-ignition-project