### PR TITLE
link to cert-manager docs instead of hardcoding install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Stoker tends your Ignition gateways, continuously feeding them configuration fro
 
 ```bash
 # Install cert-manager (required for webhook TLS)
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+# https://cert-manager.io/docs/installation/
 
 # Install the operator
 helm install stoker oci://ghcr.io/ia-eknorr/charts/stoker-operator \

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -23,12 +23,7 @@ kubectl cluster-info
 ```
 :::
 
-If cert-manager isn't installed yet:
-
-```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
-kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
-```
+If cert-manager isn't installed yet, follow the [default static install](https://cert-manager.io/docs/installation/#default-static-install) or any method from the [cert-manager docs](https://cert-manager.io/docs/installation/).
 
 ## 1. Install the Stoker operator
 


### PR DESCRIPTION
### 📖 Background

The quickstart and README hardcoded a specific cert-manager version and included a `kubectl wait` that isn't necessary.

### ⚙️ Changes

- Replace hardcoded cert-manager `kubectl apply` with link to cert-manager installation docs
- Remove `kubectl wait` from quickstart

### 📝 Reviewer Notes

Uses `/docs/installation/#default-static-install` anchor for the direct method link.

### ☑️ Testing Notes

`cd docs && npm run build` passes.