### PR TITLE
fix quickstart timing estimate and tag reference

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -183,7 +183,7 @@ kubectl get events -n quickstart --sort-by=.lastTimestamp | tail -15
 kubectl get gs -n quickstart
 ```
 
-After about 60 seconds you should see:
+After 1-2 minutes you should see:
 
 ```text
 NAME         REF    COMMIT    PROFILES   SYNCED   GATEWAYS             READY   AGE
@@ -239,7 +239,7 @@ Try changing the git ref to a specific tag:
 
 ```bash
 kubectl patch gatewaysync quickstart -n quickstart --type=merge \
-  -p '{"spec":{"git":{"ref":"v0.1.0"}}}'
+  -p '{"spec":{"git":{"ref":"0.2.0"}}}'
 ```
 
 Watch the agent pick up the change:


### PR DESCRIPTION
### 📖 Background

Validated the quickstart guide end-to-end against the published 0.2.0 Helm chart on kind-dev. Found two inaccuracies.

### ⚙️ Changes

- Updated sync timing estimate from "about 60 seconds" to "1-2 minutes" to account for the controller's requeue cycle after the agent finishes scanning
- Changed the ref-change example from `v0.1.0` (tag doesn't exist) to `0.2.0` (valid tag with the correct directory structure for the quickstart mappings)

### 📝 Reviewer Notes

The `0.1.0` tag in test-ignition-project has a different directory structure than `main`/`0.2.0`, so `services/ignition-blue/projects/` doesn't exist at that ref — the `required: true` mapping correctly fails.

### ☑️ Testing Notes

Verified by running the full quickstart on kind-dev with stoker 0.2.0 from the published OCI chart.