### PR TITLE
prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.3.0] - 2026-02-25
+
+### Breaking Changes
+
+- **Renamed `gateway.apiKeySecretRef`** to `gateway.api.secretName` / `gateway.api.secretKey` — `secretKey` defaults to `"apiKey"` when omitted, reducing boilerplate (#79)
+- Gateway port default changed from `8043` to `8088` and TLS default changed from `true` to `false`, matching Ignition Helm chart defaults (#76)
+- Webhook receiver disabled by default — enable via `webhookReceiver.enabled: true` in Helm values (#76)
+
+### Added
+
+- **GitHub App authentication** — controller exchanges PEM for short-lived installation tokens with per-CR cache and 5-minute pre-expiry refresh; PEM never leaves controller namespace; supports GitHub Enterprise Server via `apiBaseURL` field (#76)
+
 ## [v0.2.0] - 2026-02-24
 
 ### Breaking Changes
@@ -63,6 +75,7 @@ Initial release — controller + agent sidecar for Git-driven Ignition gateway c
 - **Functional test suite** with phased kind cluster tests (phases 02-09)
 - Unit tests with envtest for controller and syncengine
 
+[v0.3.0]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.2.0
 [v0.1.2]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.1.2
 [v0.1.1]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.1.1

--- a/charts/stoker-operator/Chart.yaml
+++ b/charts/stoker-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stoker-operator
 description: Kubernetes operator that syncs Ignition gateway projects from a Git repository
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 kubeVersion: ">= 1.28.0"
 home: https://github.com/ia-eknorr/stoker-operator
 icon: https://raw.githubusercontent.com/ia-eknorr/stoker-operator/main/docs/static/img/logo.png

--- a/charts/stoker-operator/README.md
+++ b/charts/stoker-operator/README.md
@@ -1,6 +1,6 @@
 # stoker-operator
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Kubernetes operator that syncs Ignition gateway projects from a Git repository
 

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -20,9 +20,17 @@ CRD consolidation, bug fixes, and developer experience.
 - 5 bug fixes across controller, agent, and webhook
 - Documentation site with quickstart, guides, and CRD reference
 - Chainsaw e2e test suite replacing shell functional tests
-- GitHub App authentication with controller-mediated token exchange, per-CR cache, and GitHub Enterprise Server support
 
-## v0.3.0 — Reliability
+## v0.3.0 — Auth & API Ergonomics ✓
+
+GitHub App authentication and CRD cleanup.
+
+- GitHub App authentication with controller-mediated token exchange, per-CR cache with 5-minute pre-expiry refresh, and GitHub Enterprise Server support via `apiBaseURL`
+- **Breaking:** renamed `gateway.apiKeySecretRef` to `gateway.api.secretName` / `gateway.api.secretKey` with `secretKey` defaulting to `"apiKey"` when omitted
+- Fixed gateway port/TLS defaults to `8088`/`false` (matching Ignition Helm chart defaults)
+- Webhook receiver disabled by default (enable via Helm value)
+
+## v0.4.0 — Reliability
 
 Focus on observability, conflict handling, and recovery.
 
@@ -33,7 +41,7 @@ Focus on observability, conflict handling, and recovery.
 - K8s informer-based ConfigMap watch (replace polling with scoped informer)
 - In-flight sync completion deadline on shutdown
 
-## v0.4.0 — Observability & Conditions
+## v0.5.0 — Observability & Conditions
 
 Focus on condition types, multi-tenancy, and dependency ordering.
 
@@ -44,7 +52,7 @@ Focus on condition types, multi-tenancy, and dependency ordering.
 - Per-gateway sync status conditions on the GatewaySync CR
 - Resource quotas and rate limiting for concurrent syncs
 
-## v0.5.0+ — Enterprise & Future
+## v0.6.0+ — Enterprise & Future
 
 - Rollback support: snapshot before sync, revert on failure
 - Bidirectional sync: watch gateway for designer changes, push back to git


### PR DESCRIPTION
### 📖 Background

Bumps the project to v0.3.0 for the breaking CRD change (`apiKeySecretRef` → `gateway.api`) and GitHub App auth feature that landed after v0.2.0.

### ⚙️ Changes

- Added v0.3.0 CHANGELOG entry (breaking changes + GitHub App auth)
- Bumped Helm chart version and appVersion to 0.3.0
- Regenerated Helm README badges
- Updated public roadmap: added v0.3.0 (Auth & API Ergonomics ✓), moved GitHub App auth from v0.2.0 to v0.3.0 where it actually shipped, bumped future milestones +1 minor version

### 📝 Reviewer Notes

After merge, tag `v0.3.0` on main to trigger the release workflow.

### ☑️ Testing Notes

- `helm template stoker-operator charts/stoker-operator/` renders correctly with 0.3.0 version
- Roadmap version sequence is consistent (v0.1.0 → v0.2.0 → v0.3.0 → v0.4.0 → v0.5.0 → v0.6.0+)