### PR TITLE
update roadmap and docs for v0.4.x releases

### DIFF
--- a/docs/docs/guides/multi-site-deployment.md
+++ b/docs/docs/guides/multi-site-deployment.md
@@ -220,7 +220,7 @@ Each site has its own namespace with:
 - Its own GatewaySync CR (can track different refs per site)
 - Its own GitHub App token Secret (created by the controller)
 - Its own gateway API key Secret
-- Namespace label `stoker.io/injection=enabled`
+- Namespace label `stoker.io/injection=enabled` (only if `webhook.namespaceSelector.requireLabel=true`)
 
 ## Important: protect the `.uuid` file
 

--- a/docs/docs/reference/helm-values.md
+++ b/docs/docs/reference/helm-values.md
@@ -34,6 +34,8 @@ helm install stoker oci://ghcr.io/ia-eknorr/charts/stoker-operator \
 | `resources.limits.memory` | string | `128Mi` | Controller memory limit. |
 | `nodeSelector` | object | `{}` | Node selector labels for the controller pod. |
 | `tolerations` | list | `[]` | Tolerations for scheduling on tainted nodes. |
+| `podAnnotations` | object | `{}` | Additional annotations to add to the controller pod. |
+| `podLabels` | object | `{}` | Additional labels to add to the controller pod. |
 | `affinity` | object | `{}` | Affinity rules for the controller pod. |
 
 ### cert-manager

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -6,17 +6,23 @@ description: Planned features and milestones for Stoker.
 
 # Roadmap
 
-Current version: **v0.4.0** — [see the changelog](https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md) for release history.
+Current version: **v0.4.3** — [see the changelog](https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md) for release history.
 
-## v0.4.0 — Content Templating & Config Transforms
+## v0.4.x — Content Templating, Config Transforms & Agent Hardening
 
-Multi-site GitOps and surgical config overrides — the prerequisites for production multi-gateway deployments.
+Multi-site GitOps, surgical config overrides, and production reliability improvements.
 
 - ✅ **Content templating** (`template: true`) — resolve `{{.GatewayName}}`, `{{.PodName}}`, `{{.Vars.key}}`, and all context variables inside file **contents** at sync time; binary files rejected with a clear error
 - ✅ **`vars` in `spec.sync.defaults`** — define default template variables shared across all profiles; profile `vars` override per-key
 - ✅ **`{{.PodName}}` in TemplateContext** — enables unique system names for StatefulSet replicas
 - ✅ **GitHub App tokens → Secret** — installation tokens written to a controller-managed Secret (`stoker-github-token-{crName}`) and mounted into agent pods; no longer stored in ConfigMap
 - ✅ **JSON path patches** — per-mapping `patches` blocks that set specific JSON fields at sync time using sjson dot-notation paths; values resolve Go template syntax; `file` field supports doublestar globs; `type` field optional and inferred from filesystem
+- ✅ **`{{.PodOrdinal}}` template variable** — StatefulSet replica index from `apps.kubernetes.io/pod-index` label with pod-name fallback; enables `"{{.Vars.projectName}}-{{.PodOrdinal}}"` patterns
+- ✅ **Var key validation** — `vars` keys validated as Go identifiers at reconcile time; invalid keys produce a clear `ProfilesValid=False` condition
+- ✅ **`podAnnotations` and `podLabels` Helm values** — add arbitrary annotations and labels to the controller pod
+- ✅ **Increased agent startup probe timeout** — `failureThreshold` raised to 150 (5 min) to accommodate initial clone of large repositories
+- ✅ **Native git for agent clone/fetch** — replaced go-git with `exec.Command("git", ...)` using shallow clones; eliminates OOM kills on large repos
+- ✅ **Alpine-based agent image** — replaced distroless with `alpine:3.21 + git + openssh-client`; same security context
 
 ## v0.5.0 — Observability & Reliability
 


### PR DESCRIPTION
### 📖 Background
The roadmap and docs were out of sync after the v0.4.1–v0.4.3 releases. The roadmap still showed v0.4.0 as current, the helm values reference was missing new values, and the multi-site guide implied the namespace injection label was always required.

### ⚙️ Changes
- **Roadmap**: bump current version to v0.4.3, rename section to "v0.4.x", add completed items for PodOrdinal, var key validation, podAnnotations/podLabels, startup probe timeout, native git, and Alpine agent image
- **Helm values reference**: add `podAnnotations` and `podLabels` to the values table (added in v0.4.2)
- **Multi-site guide**: clarify that `stoker.io/injection=enabled` namespace label is only needed when `requireLabel=true`

### 📝 Reviewer Notes
Documentation-only changes. No code modified.

### ☑️ Testing Notes
Verify the docs site renders correctly with `cd docs && npm start`.