### PR TITLE
add missing PodOrdinal and secret-type annotation to docs

### DIFF
--- a/docs/docs/guides/content-templating.md
+++ b/docs/docs/guides/content-templating.md
@@ -34,6 +34,7 @@ Any file in `config/system-properties/` that contains `{{...}}` syntax is render
 |----------|---------|-------------|
 | `{{.GatewayName}}` | `ignition-site1` | Gateway identity from annotation or `app.kubernetes.io/name` label |
 | `{{.PodName}}` | `ignition-0` | Kubernetes pod name (useful for StatefulSet replicas) |
+| `{{.PodOrdinal}}` | `0` | StatefulSet replica index (from `apps.kubernetes.io/pod-index` label with pod-name fallback; always `0` for non-StatefulSet pods) |
 | `{{.Namespace}}` | `production` | Kubernetes namespace of the gateway pod |
 | `{{.CRName}}` | `site1-sync` | Name of the GatewaySync CR |
 | `{{.Ref}}` | `refs/heads/main` | Git ref being synced |

--- a/docs/docs/reference/annotations.md
+++ b/docs/docs/reference/annotations.md
@@ -63,11 +63,12 @@ These annotations trigger an immediate reconciliation via the controller's predi
 |------------|-------|-------------|
 | `stoker.io/injected` | `"true"` | Set by the mutating webhook after successful sidecar injection. Used for tracking — do not set manually. |
 
-## Labels on owned resources
+## Annotations and labels on owned resources
 
-| Label | Value | Set on | Description |
-|-------|-------|--------|-------------|
-| `stoker.io/cr-name` | CR name | ConfigMaps | Identifies the parent GatewaySync CR that owns this resource |
+| Key | Type | Value | Set on | Description |
+|-----|------|-------|--------|-------------|
+| `stoker.io/cr-name` | Label | CR name | ConfigMaps, Secrets | Identifies the parent GatewaySync CR that owns this resource |
+| `stoker.io/secret-type` | Annotation | `"github-app-token"` | Secrets | Marks controller-managed Secrets with their purpose |
 
 ## Agent image resolution order
 


### PR DESCRIPTION
### 📖 Background
Audit of docs vs codebase found two gaps: the content templating guide's variables table was missing `{{.PodOrdinal}}` (added in v0.4.1), and the `stoker.io/secret-type` annotation used on controller-managed GitHub App token Secrets wasn't documented.

### ⚙️ Changes
- **Content templating guide**: add `{{.PodOrdinal}}` to the available template variables table
- **Annotations reference**: add `stoker.io/secret-type` annotation and expand the owned resources section to cover both labels and annotations on Secrets

### 📝 Reviewer Notes
Documentation-only changes. No code modified.

### ☑️ Testing Notes
Verify the docs site renders correctly with `cd docs && npm start`.