### PR TITLE
add webhookReceiver.ingress to Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.4.7] - 2026-03-01
+
+### Added
+
+- **Webhook receiver Ingress** — `webhookReceiver.ingress` block in Helm values; creates an Ingress resource exposing the receiver outside the cluster for push-event-driven syncs from Kargo, GitHub, or other external systems; generic annotations/hosts/tls structure works with any ingress controller (ALB, nginx, Traefik)
+
 ## [v0.4.6] - 2026-02-28
 
 ### Fixed
@@ -150,6 +156,7 @@ Initial release — controller + agent sidecar for Git-driven Ignition gateway c
 - **Functional test suite** with phased kind cluster tests (phases 02-09)
 - Unit tests with envtest for controller and syncengine
 
+[v0.4.7]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.4.7
 [v0.4.6]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.4.6
 [v0.4.5]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.4.5
 [v0.4.4]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.4.4

--- a/charts/stoker-operator/Chart.yaml
+++ b/charts/stoker-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stoker-operator
 description: Kubernetes operator that syncs Ignition gateway projects from a Git repository
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.7
+appVersion: "0.4.7"
 kubeVersion: ">= 1.28.0"
 home: https://github.com/ia-eknorr/stoker-operator
 icon: https://raw.githubusercontent.com/ia-eknorr/stoker-operator/main/docs/static/img/logo.png

--- a/charts/stoker-operator/templates/webhook-receiver-ingress.yaml
+++ b/charts/stoker-operator/templates/webhook-receiver-ingress.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.webhookReceiver.enabled .Values.webhookReceiver.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "stoker-operator.fullname" . }}-webhook-receiver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stoker-operator.labels" . | nindent 4 }}
+  {{- with .Values.webhookReceiver.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.webhookReceiver.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.webhookReceiver.ingress.ingressClassName }}
+  {{- end }}
+  {{- if .Values.webhookReceiver.ingress.tls }}
+  tls:
+    {{- toYaml .Values.webhookReceiver.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- range .Values.webhookReceiver.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- range .paths }}
+      - path: {{ .path }}
+        pathType: {{ .pathType }}
+        backend:
+          service:
+            name: {{ include "stoker-operator.fullname" $ }}-webhook-receiver
+            port:
+              number: {{ $.Values.webhookReceiver.port | default 9444 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/stoker-operator/values.yaml
+++ b/charts/stoker-operator/values.yaml
@@ -121,6 +121,39 @@ webhookReceiver:
       name: ""
       # -- Key within the Secret.
       key: "webhook-secret"
+  # -- Ingress for the webhook receiver. Exposes the receiver outside the cluster
+  # for push-event-driven syncs from Kargo, GitHub, or other external systems.
+  ingress:
+    # -- Create an Ingress resource for the webhook receiver.
+    enabled: false
+    # -- Ingress class name (e.g. "nginx", "traefik", "alb").
+    # When empty, the cluster default ingress class is used.
+    ingressClassName: ""
+    # -- Annotations for the Ingress resource. Use to configure your ingress
+    # controller or attach a cert-manager certificate.
+    # Example (AWS ALB internal):
+    #   kubernetes.io/ingress.class: alb
+    #   alb.ingress.kubernetes.io/scheme: internal
+    #   alb.ingress.kubernetes.io/group.name: my-group
+    #   alb.ingress.kubernetes.io/target-type: ip
+    # Example (nginx + cert-manager):
+    #   cert-manager.io/cluster-issuer: letsencrypt-prod
+    #   nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    annotations: {}
+    # -- Hosts and paths to expose. At least one host is required when enabled.
+    # Example:
+    #   - host: stoker.example.com
+    #     paths:
+    #       - path: /webhook
+    #         pathType: Prefix
+    hosts: []
+    # -- TLS configuration. Omit to rely on ingress controller defaults or
+    # cert-manager annotations.
+    # Example:
+    #   - secretName: stoker-webhook-tls
+    #     hosts:
+    #       - stoker.example.com
+    tls: []
 
 # -- Additional annotations to add to the controller pod.
 podAnnotations: {}


### PR DESCRIPTION
## Background

The webhook receiver was ClusterIP-only with no built-in Ingress support. Operators deployed in a management cluster (or any cross-cluster setup) couldn't reach it. Users were forced to create wrapper templates in their consumer repos.

## Changes

- `webhookReceiver.ingress` block nested under the existing `webhookReceiver` section — following the Flux2 convention for webhook receiver ingress
- Generic `annotations`, `hosts`, `tls` structure — works with any ingress controller (ALB, nginx, Traefik, etc.)
- `ingressClassName` as a spec field (K8s 1.18+ standard)
- Disabled by default; only renders when both `webhookReceiver.enabled` and `webhookReceiver.ingress.enabled` are true

## Usage

```yaml
webhookReceiver:
  enabled: true
  ingress:
    enabled: true
    annotations:
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/scheme: internal
      alb.ingress.kubernetes.io/group.name: my-group
    hosts:
      - host: stoker.example.com
        paths:
          - path: /webhook
            pathType: Prefix
```