### PR TITLE
fix: orphan cleanup skips nested managed roots (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.5.1] - 2026-03-05
+
+### Fixed
+
+- **Orphan cleanup skips nested managed roots** — `cleanOrphans` and `computeDryRunDiff` returned `filepath.SkipDir` for any directory not directly under a managed root (e.g. `config/`), preventing traversal into nested destinations like `config/resources/dev/ignition/audit-profile`; orphan files and directories inside them were never deleted (`deleted: 0`); fix adds `isAncestorOfManagedRoot` to allow traversal through intermediate directories, and bubbles up empty directory removal after orphan file deletion (#99, #100)
+
 ## [v0.5.0] - 2026-03-01
 
 ### Added
@@ -183,6 +189,7 @@ Initial release — controller + agent sidecar for Git-driven Ignition gateway c
 - **Functional test suite** with phased kind cluster tests (phases 02-09)
 - Unit tests with envtest for controller and syncengine
 
+[v0.5.1]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.5.1
 [v0.5.0]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.5.0
 [v0.4.10]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.4.10
 [v0.4.9]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.4.9

--- a/internal/syncengine/plan.go
+++ b/internal/syncengine/plan.go
@@ -248,6 +248,20 @@ func isUnderManagedRoot(relPath string, managedRoots map[string]bool) bool {
 	return false
 }
 
+// isAncestorOfManagedRoot returns true if relPath is a strict parent directory
+// of any managed root. For example, "config" is an ancestor of
+// "config/resources/core". Used to allow traversal into parent directories
+// without treating them as managed (i.e. eligible for orphan deletion).
+func isAncestorOfManagedRoot(relPath string, managedRoots map[string]bool) bool {
+	relPath = filepath.ToSlash(relPath)
+	for root := range managedRoots {
+		if strings.HasPrefix(root, relPath+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 // mergeStagingToLive walks staging and copies changed files to live.
 func mergeStagingToLive(stagingDir, liveDir string) (added, modified int, err error) {
 	err = filepath.WalkDir(stagingDir, func(stagingPath string, d fs.DirEntry, walkErr error) error {
@@ -332,6 +346,11 @@ func cleanOrphans(stagingDir, liveDir string, managedRoots map[string]bool, excl
 		// Only clean within managed roots.
 		if !isUnderManagedRoot(relPath, managedRoots) {
 			if d.IsDir() {
+				// Traverse into parent directories of managed roots so we can
+				// reach nested managed subtrees (e.g. "config" → "config/resources/dev").
+				if isAncestorOfManagedRoot(relPath, managedRoots) {
+					return nil
+				}
 				return filepath.SkipDir
 			}
 			return nil
@@ -348,6 +367,22 @@ func cleanOrphans(stagingDir, liveDir string, managedRoots map[string]bool, excl
 				return fmt.Errorf("removing orphan %s: %w", relPath, removeErr)
 			}
 			deleted++
+			// Remove now-empty parent directories up to the managed root boundary.
+			parentDir := filepath.Dir(livePath)
+			for {
+				parentRel, relErr := filepath.Rel(liveDir, parentDir)
+				if relErr != nil || !isUnderManagedRoot(filepath.ToSlash(parentRel), managedRoots) {
+					break
+				}
+				entries, rdErr := os.ReadDir(parentDir)
+				if rdErr != nil || len(entries) > 0 {
+					break
+				}
+				if rmErr := os.Remove(parentDir); rmErr != nil {
+					break
+				}
+				parentDir = filepath.Dir(parentDir)
+			}
 		}
 		return nil
 	})
@@ -417,6 +452,11 @@ func computeDryRunDiff(stagingDir, liveDir string, managedRoots map[string]bool,
 
 		if !isUnderManagedRoot(relPath, managedRoots) {
 			if d.IsDir() {
+				// Traverse into parent directories of managed roots so we can
+				// reach nested managed subtrees (e.g. "config" → "config/resources/dev").
+				if isAncestorOfManagedRoot(relPath, managedRoots) {
+					return nil
+				}
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/syncengine/plan_test.go
+++ b/internal/syncengine/plan_test.go
@@ -489,6 +489,78 @@ func TestExecutePlan_RootLevelFileMappingDoesNotOrphanUnmanagedPaths(t *testing.
 	}
 }
 
+func TestExecutePlan_OrphanCleanup_NestedManagedRoot(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	staging := filepath.Join(tmp, "staging")
+	live := filepath.Join(tmp, "live")
+
+	// Git source has only "Features" — "Audit" was removed.
+	writeTestFile(t, filepath.Join(src, "Features", "config.json"), `{}`)
+
+	// Live gateway still has "Audit" from a prior sync (the orphan).
+	writeTestFile(t, filepath.Join(live, "config", "resources", "dev", "ignition", "audit-profile", "Audit", "config.json"), `{}`)
+	writeTestFile(t, filepath.Join(live, "config", "resources", "dev", "ignition", "audit-profile", "Features", "config.json"), `{}`)
+
+	engine := &Engine{}
+	plan := &SyncPlan{
+		Mappings: []ResolvedMapping{
+			{Source: src, Destination: "config/resources/dev/ignition/audit-profile", Type: "dir"},
+		},
+		StagingDir: staging,
+		LiveDir:    live,
+	}
+
+	result, err := engine.ExecutePlan(plan)
+	if err != nil {
+		t.Fatalf("ExecutePlan: %v", err)
+	}
+
+	// "Audit" must be deleted — it is not in git.
+	if _, err := os.Stat(filepath.Join(live, "config", "resources", "dev", "ignition", "audit-profile", "Audit")); !os.IsNotExist(err) {
+		t.Error("Audit/ should have been deleted by orphan cleanup")
+	}
+	// "Features" must survive — it is in git.
+	if _, err := os.Stat(filepath.Join(live, "config", "resources", "dev", "ignition", "audit-profile", "Features", "config.json")); err != nil {
+		t.Error("Features/config.json should have been preserved")
+	}
+	if result.FilesDeleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", result.FilesDeleted)
+	}
+}
+
+func TestExecutePlan_DryRun_NestedManagedRoot_DetectsOrphan(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	staging := filepath.Join(tmp, "staging")
+	live := filepath.Join(tmp, "live")
+
+	writeTestFile(t, filepath.Join(src, "keep.json"), `{}`)
+	writeTestFile(t, filepath.Join(live, "config", "resources", "dev", "keep.json"), `{}`)
+	writeTestFile(t, filepath.Join(live, "config", "resources", "dev", "orphan.json"), `{}`)
+
+	engine := &Engine{}
+	plan := &SyncPlan{
+		Mappings: []ResolvedMapping{
+			{Source: src, Destination: "config/resources/dev", Type: "dir"},
+		},
+		StagingDir: staging,
+		LiveDir:    live,
+		DryRun:     true,
+	}
+
+	result, err := engine.ExecutePlan(plan)
+	if err != nil {
+		t.Fatalf("ExecutePlan: %v", err)
+	}
+	if result.DryRunDiff == nil {
+		t.Fatal("expected DryRunDiff")
+	}
+	if len(result.DryRunDiff.Deleted) != 1 {
+		t.Errorf("expected 1 deleted in dry-run diff, got %d: %v", len(result.DryRunDiff.Deleted), result.DryRunDiff.Deleted)
+	}
+}
+
 // Helpers
 
 func writeTestFile(t *testing.T, path, content string) {


### PR DESCRIPTION
### 📖 Background
`cleanOrphans` and `computeDryRunDiff` use `isUnderManagedRoot` to decide whether to traverse or skip directories during the live-dir walk. This function only checks if a path is a *descendant* of a managed root — not if it is an *ancestor*. When the walker hit `config/` and no managed root was `config` itself, `filepath.SkipDir` was returned, pruning the entire subtree. This meant `config/resources/core`, `config/resources/dev`, etc. were never walked and orphan files inside them were never deleted.

Discovered via: Audit Profile "Audit" surviving a 2.2.4 deployment in public-demo dev-us-west-2 despite being absent from git (`deleted: 0` in sync log). Fixes #99.

### ⚙️ Changes
- Add `isAncestorOfManagedRoot` helper: returns true if a path is a strict parent of any managed root, allowing the walker to traverse through intermediate directories
- Fix `cleanOrphans` and `computeDryRunDiff` to use the new helper — only skip dirs that are neither under nor an ancestor of a managed root
- Add empty-directory bubble-up in `cleanOrphans`: after removing an orphan file, walk up and remove now-empty parent directories while still within the managed root boundary (e.g., `Audit/config.json` gone → `Audit/` removed too)

### 📝 Reviewer Notes
The fix is purely in `internal/syncengine/plan.go`. No API type changes, no CRD/Helm changes.

`isAncestorOfManagedRoot` is never called for file-mapped destinations (e.g. `.versions.json`) because file paths don't end in `/`, so `strings.HasPrefix(root, ".versions.json/")` is always false — no behaviour change for file mappings.

### ☑️ Testing Notes
Two regression tests added:
- `TestExecutePlan_OrphanCleanup_NestedManagedRoot` — destination at `config/resources/dev/ignition/audit-profile`; plants an orphan `Audit/config.json`, verifies it's deleted and `Features/config.json` survives
- `TestExecutePlan_DryRun_NestedManagedRoot_DetectsOrphan` — same setup in dry-run mode, verifies the deleted diff is populated

```
go test ./internal/syncengine/ -v
```
All 19 tests pass.