### PR TITLE
fix: resolve goconst lint violations from golangci-lint v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,8 @@ linters:
     - unparam
     - unused
   settings:
+    goconst:
+      ignore-tests: true
     revive:
       rules:
         - name: comment-spacings

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -29,6 +29,11 @@ import (
 	stokertypes "github.com/ia-eknorr/stoker-operator/pkg/types"
 )
 
+const (
+	gitAccessTokenUser = "x-access-token"
+	defaultProfileName = "default"
+)
+
 // agentVersion is set at build time via ldflags. Falls back to "dev" for local builds.
 var agentVersion = "dev"
 
@@ -294,7 +299,7 @@ func (a *Agent) handleSyncTrigger(ctx context.Context, gitURL string, auth trans
 	// Refresh auth from metadata if GitHub App token was updated by controller.
 	if meta.GitToken != "" {
 		auth = &gogithttp.BasicAuth{
-			Username: "x-access-token",
+			Username: gitAccessTokenUser,
 			Password: meta.GitToken,
 		}
 	}
@@ -408,7 +413,7 @@ func (a *Agent) lookupProfile(meta *Metadata) (*stokertypes.ResolvedProfile, str
 
 	profileName := a.Config.ProfileName
 	if profileName == "" {
-		profileName = "default"
+		profileName = defaultProfileName
 	}
 
 	profile, ok := profiles[profileName]
@@ -762,7 +767,7 @@ func (a *Agent) resolveAuth(meta *Metadata) transport.AuthMethod {
 	// GitHub App: token delivered via metadata ConfigMap.
 	if meta != nil && meta.GitToken != "" {
 		return &gogithttp.BasicAuth{
-			Username: "x-access-token",
+			Username: gitAccessTokenUser,
 			Password: meta.GitToken,
 		}
 	}
@@ -792,7 +797,7 @@ func (a *Agent) resolveFileAuth() transport.AuthMethod {
 	// Token auth.
 	if token := a.Config.GitToken(); token != "" {
 		return &gogithttp.BasicAuth{
-			Username: "x-access-token",
+			Username: gitAccessTokenUser,
 			Password: token,
 		}
 	}

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -8,6 +8,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const (
+	metricsNamespace = "stoker"
+	metricsSubsystem = "agent"
+	labelProfile     = "profile"
+	labelResult      = "result"
+)
+
 // AgentMetrics holds Prometheus metrics for the agent sidecar.
 // It uses a standalone registry (agent is not a controller-runtime manager).
 type AgentMetrics struct {
@@ -44,36 +51,36 @@ func NewAgentMetrics() *AgentMetrics {
 
 		SyncDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "sync_duration_seconds",
 				Help:      "Duration of file sync operations in seconds.",
 				Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
 			},
-			[]string{"profile"},
+			[]string{labelProfile},
 		),
 		SyncTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "sync_total",
 				Help:      "Total number of sync operations.",
 			},
-			[]string{"profile", "result"},
+			[]string{labelProfile, labelResult},
 		),
 		FilesChanged: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "files_changed",
 				Help:      "Number of files changed in the last sync.",
 			},
-			[]string{"profile"},
+			[]string{labelProfile},
 		),
 		GitFetchDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "git_fetch_duration_seconds",
 				Help:      "Duration of git clone/fetch operations in seconds.",
 				Buckets:   []float64{0.5, 1, 2, 5, 10, 30, 60, 120},
@@ -82,17 +89,17 @@ func NewAgentMetrics() *AgentMetrics {
 		),
 		GitFetchTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "git_fetch_total",
 				Help:      "Total number of git clone/fetch operations.",
 			},
-			[]string{"operation", "result"},
+			[]string{"operation", labelResult},
 		),
 		ScanDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "scan_duration_seconds",
 				Help:      "Duration of Ignition scan API calls in seconds.",
 				Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
@@ -100,33 +107,33 @@ func NewAgentMetrics() *AgentMetrics {
 		),
 		ScanTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "scan_total",
 				Help:      "Total number of Ignition scan operations.",
 			},
-			[]string{"result"},
+			[]string{labelResult},
 		),
 		DesignerBlocked: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "designer_sessions_blocked",
 				Help:      "Whether sync is currently blocked by active designer sessions (1=blocked, 0=not).",
 			},
 		),
 		LastSyncTimestamp: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "last_sync_timestamp_seconds",
 				Help:      "Unix timestamp of the last successful sync.",
 			},
 		),
 		LastSyncSuccess: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "last_sync_success",
 				Help:      "Whether the last sync was successful (1=success, 0=error).",
 			},
@@ -134,43 +141,43 @@ func NewAgentMetrics() *AgentMetrics {
 
 		FilesAdded: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "files_added",
 				Help:      "Number of files added in the last sync.",
 			},
-			[]string{"profile"},
+			[]string{labelProfile},
 		),
 		FilesModified: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "files_modified",
 				Help:      "Number of files modified in the last sync.",
 			},
-			[]string{"profile"},
+			[]string{labelProfile},
 		),
 		FilesDeleted: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "files_deleted",
 				Help:      "Number of files deleted in the last sync.",
 			},
-			[]string{"profile"},
+			[]string{labelProfile},
 		),
 		DesignerSessionsActive: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "designer_sessions_active",
 				Help:      "Number of active Ignition Designer sessions.",
 			},
 		),
 		SyncSkippedTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "sync_skipped_total",
 				Help:      "Total number of sync operations skipped.",
 			},
@@ -178,8 +185,8 @@ func NewAgentMetrics() *AgentMetrics {
 		),
 		GatewayStartupDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
-				Namespace: "stoker",
-				Subsystem: "agent",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
 				Name:      "gateway_startup_duration_seconds",
 				Help:      "Time from agent startup to gateway becoming responsive.",
 				Buckets:   []float64{5, 10, 30, 60, 120, 300, 600},

--- a/internal/controller/gateway_discovery.go
+++ b/internal/controller/gateway_discovery.go
@@ -85,7 +85,7 @@ func (r *GatewaySyncReconciler) discoverGateways(ctx context.Context, gs *stoker
 		// Capture ServiceAccount for auto-RBAC binding.
 		saName := pod.Spec.ServiceAccountName
 		if saName == "" {
-			saName = "default"
+			saName = defaultServiceAccount
 		}
 
 		gateway := stokerv1alpha1.DiscoveredGateway{

--- a/internal/controller/gatewaysync_controller.go
+++ b/internal/controller/gatewaysync_controller.go
@@ -687,8 +687,8 @@ func (r *GatewaySyncReconciler) ensureMetadataConfigMap(ctx context.Context, gs 
 				Name:      cmName,
 				Namespace: gs.Namespace,
 				Labels: map[string]string{
-					labelManagedBy: "stoker-controller",
-					stokertypes.LabelCRName:        gs.Name,
+					labelManagedBy:          "stoker-controller",
+					stokertypes.LabelCRName: gs.Name,
 				},
 			},
 			Data: data,
@@ -725,8 +725,8 @@ func (r *GatewaySyncReconciler) ensureGitHubTokenSecret(ctx context.Context, gs 
 				Name:      secretName,
 				Namespace: gs.Namespace,
 				Labels: map[string]string{
-					labelManagedBy: "stoker-controller",
-					stokertypes.LabelCRName:        gs.Name,
+					labelManagedBy:          "stoker-controller",
+					stokertypes.LabelCRName: gs.Name,
 				},
 				Annotations: map[string]string{
 					stokertypes.AnnotationSecretType: "github-app-token",

--- a/internal/controller/gatewaysync_controller.go
+++ b/internal/controller/gatewaysync_controller.go
@@ -687,7 +687,7 @@ func (r *GatewaySyncReconciler) ensureMetadataConfigMap(ctx context.Context, gs 
 				Name:      cmName,
 				Namespace: gs.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by": "stoker-controller",
+					labelManagedBy: "stoker-controller",
 					stokertypes.LabelCRName:        gs.Name,
 				},
 			},
@@ -725,7 +725,7 @@ func (r *GatewaySyncReconciler) ensureGitHubTokenSecret(ctx context.Context, gs 
 				Name:      secretName,
 				Namespace: gs.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by": "stoker-controller",
+					labelManagedBy: "stoker-controller",
 					stokertypes.LabelCRName:        gs.Name,
 				},
 				Annotations: map[string]string{

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -12,78 +12,82 @@ import (
 
 // Reconcile result label values.
 const (
-	resultSuccess = "success"
-	resultError   = "error"
-	resultRequeue = "requeue"
+	resultSuccess    = "success"
+	resultError      = "error"
+	resultRequeue    = "requeue"
+	metricsNamespace = "stoker"
+	metricsSubsystem = "controller"
+	labelName        = "name"
+	labelNamespace   = "namespace"
 )
 
 var (
 	reconcileDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "reconcile_duration_seconds",
 			Help:      "Duration of GatewaySync reconciliation in seconds.",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"name", "namespace"},
+		[]string{labelName, labelNamespace},
 	)
 
 	reconcileTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "reconcile_total",
 			Help:      "Total number of GatewaySync reconciliations.",
 		},
-		[]string{"name", "namespace", "result"},
+		[]string{labelName, labelNamespace, "result"},
 	)
 
 	refResolveDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "ref_resolve_duration_seconds",
 			Help:      "Duration of git ref resolution (ls-remote) in seconds.",
 			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
 		},
-		[]string{"name", "namespace"},
+		[]string{labelName, labelNamespace},
 	)
 
 	gatewaysDiscovered = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "gateways_discovered",
 			Help:      "Number of gateways discovered by the controller.",
 		},
-		[]string{"name", "namespace"},
+		[]string{labelName, labelNamespace},
 	)
 
 	gatewaysSynced = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "gateways_synced",
 			Help:      "Number of gateways in Synced state.",
 		},
-		[]string{"name", "namespace"},
+		[]string{labelName, labelNamespace},
 	)
 
 	crReady = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "cr_ready",
 			Help:      "Whether the GatewaySync CR is Ready (1=ready, 0=not ready).",
 		},
-		[]string{"name", "namespace"},
+		[]string{labelName, labelNamespace},
 	)
 
 	githubAppTokenExpiry = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "github_app_token_expiry_timestamp_seconds",
 			Help:      "Unix timestamp when the cached GitHub App token expires.",
 		},
@@ -92,62 +96,62 @@ var (
 
 	crInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "cr_info",
 			Help:      "Info metric (always 1) carrying CR labels for PromQL joins.",
 		},
-		[]string{"name", "namespace", "git_repo", "git_ref", "auth_type", "polling_interval"},
+		[]string{labelName, labelNamespace, "git_repo", "git_ref", "auth_type", "polling_interval"},
 	)
 
 	crPaused = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "cr_paused",
 			Help:      "Whether the GatewaySync CR is paused (1=paused, 0=active).",
 		},
-		[]string{"name", "namespace"},
+		[]string{labelName, labelNamespace},
 	)
 
 	conditionStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "condition_status",
 			Help:      "Status of each condition type on the GatewaySync CR (1=True, 0=False).",
 		},
-		[]string{"name", "namespace", "type"},
+		[]string{labelName, labelNamespace, "type"},
 	)
 
 	gatewaySyncStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "gateway_sync_status",
 			Help:      "Sync status of each gateway (0=Pending, 1=Synced, 2=Error, 3=MissingSidecar).",
 		},
-		[]string{"name", "namespace", "gateway"},
+		[]string{labelName, labelNamespace, "gateway"},
 	)
 
 	gatewayLastSyncTS = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "gateway_last_sync_timestamp_seconds",
 			Help:      "Unix timestamp of each gateway's last sync.",
 		},
-		[]string{"name", "namespace", "gateway"},
+		[]string{labelName, labelNamespace, "gateway"},
 	)
 
 	gatewaysMissingSidecar = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "stoker",
-			Subsystem: "controller",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
 			Name:      "gateways_missing_sidecar",
 			Help:      "Number of gateways missing the stoker-agent sidecar.",
 		},
-		[]string{"name", "namespace"},
+		[]string{labelName, labelNamespace},
 	)
 )
 
@@ -212,7 +216,7 @@ func observeGatewayMetrics(gs *stokerv1alpha1.GatewaySync) {
 	crReady.WithLabelValues(name, ns).Set(readyVal)
 
 	// CR info gauge — clear stale label combos then set with current values.
-	crInfo.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": ns})
+	crInfo.DeletePartialMatch(prometheus.Labels{labelName: name, labelNamespace: ns})
 	pollingInterval := gs.Spec.Polling.Interval
 	if pollingInterval == "" {
 		pollingInterval = "60s"
@@ -238,7 +242,7 @@ func syncStatusToFloat(status string) float64 {
 
 // cleanupCRMetrics removes all metric series associated with a CR being deleted.
 func cleanupCRMetrics(name, namespace string) {
-	labels := prometheus.Labels{"name": name, "namespace": namespace}
+	labels := prometheus.Labels{labelName: name, labelNamespace: namespace}
 	reconcileDuration.DeletePartialMatch(labels)
 	reconcileTotal.DeletePartialMatch(labels)
 	refResolveDuration.DeletePartialMatch(labels)

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -22,7 +22,9 @@ import (
 const (
 	// agentClusterRoleName is the fixed name of the agent ClusterRole.
 	// This must match the name in config/rbac/agent_role.yaml and the Helm chart template.
-	agentClusterRoleName = "stoker-agent"
+	agentClusterRoleName  = "stoker-agent"
+	defaultServiceAccount = "default"
+	labelManagedBy        = "app.kubernetes.io/managed-by"
 )
 
 // agentRoleBindingName returns the name for the auto-created RoleBinding.
@@ -42,7 +44,7 @@ func (r *GatewaySyncReconciler) ensureAgentRoleBinding(ctx context.Context, gs *
 	saNames := r.collectServiceAccountsFromPods(ctx, gs)
 	if len(saNames) == 0 {
 		// No matching pods exist yet — use "default" as a baseline subject.
-		saNames = []string{"default"}
+		saNames = []string{defaultServiceAccount}
 	}
 
 	rbName := agentRoleBindingName(gs.Name)
@@ -62,7 +64,7 @@ func (r *GatewaySyncReconciler) ensureAgentRoleBinding(ctx context.Context, gs *
 				Name:      rbName,
 				Namespace: gs.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by": "stoker-operator",
+					labelManagedBy: "stoker-operator",
 					"stoker.io/gatewaysync":        gs.Name,
 				},
 			},
@@ -130,7 +132,7 @@ func (r *GatewaySyncReconciler) collectServiceAccountsFromPods(ctx context.Conte
 		}
 		sa := pod.Spec.ServiceAccountName
 		if sa == "" {
-			sa = "default"
+			sa = defaultServiceAccount
 		}
 		seen[sa] = true
 	}

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -64,8 +64,8 @@ func (r *GatewaySyncReconciler) ensureAgentRoleBinding(ctx context.Context, gs *
 				Name:      rbName,
 				Namespace: gs.Namespace,
 				Labels: map[string]string{
-					labelManagedBy: "stoker-operator",
-					"stoker.io/gatewaysync":        gs.Name,
+					labelManagedBy:          "stoker-operator",
+					"stoker.io/gatewaysync": gs.Name,
 				},
 			},
 			RoleRef: rbacv1.RoleRef{

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -17,6 +17,8 @@ import (
 	transportclient "github.com/go-git/go-git/v5/plumbing/transport/client"
 )
 
+const gitRemoteOrigin = "origin"
+
 // Result holds the outcome of a clone or fetch operation.
 type Result struct {
 	Commit string
@@ -147,7 +149,7 @@ func (g *GoGitClient) fetchAndCheckout(ctx context.Context, repoURL, ref, path s
 
 // ensureRemoteURL updates the origin remote URL if it differs from the desired URL.
 func ensureRemoteURL(repo *gogit.Repository, desiredURL string) error {
-	remote, err := repo.Remote("origin")
+	remote, err := repo.Remote(gitRemoteOrigin)
 	if err != nil {
 		return fmt.Errorf("getting origin remote: %w", err)
 	}
@@ -156,11 +158,11 @@ func ensureRemoteURL(repo *gogit.Repository, desiredURL string) error {
 		return nil
 	}
 	// Remove and re-add origin with the correct URL
-	if err := repo.DeleteRemote("origin"); err != nil {
+	if err := repo.DeleteRemote(gitRemoteOrigin); err != nil {
 		return fmt.Errorf("deleting origin remote: %w", err)
 	}
 	if _, err := repo.CreateRemote(&gogitconfig.RemoteConfig{
-		Name: "origin",
+		Name: gitRemoteOrigin,
 		URLs: []string{desiredURL},
 	}); err != nil {
 		return fmt.Errorf("creating origin remote: %w", err)
@@ -355,10 +357,10 @@ func nativeCloneAndCheckout(ctx context.Context, repoURL, ref, path string, env 
 
 func nativeFetchAndCheckout(ctx context.Context, repoURL, ref, path string, env []string) (Result, error) {
 	// Update remote URL in case it changed in the CR spec.
-	if _, err := runGit(ctx, []string{"remote", "set-url", "origin", repoURL}, path, env); err != nil {
+	if _, err := runGit(ctx, []string{"remote", "set-url", gitRemoteOrigin, repoURL}, path, env); err != nil {
 		return Result{}, fmt.Errorf("git remote set-url: %w", err)
 	}
-	if _, err := runGit(ctx, []string{"fetch", "--depth=1", "origin", ref}, path, env); err != nil {
+	if _, err := runGit(ctx, []string{"fetch", "--depth=1", gitRemoteOrigin, ref}, path, env); err != nil {
 		return Result{}, fmt.Errorf("git fetch: %w", err)
 	}
 	if _, err := runGit(ctx, []string{"checkout", "-f", "FETCH_HEAD"}, path, env); err != nil {

--- a/internal/git/githubapp.go
+++ b/internal/git/githubapp.go
@@ -14,7 +14,10 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-const defaultGitHubAPIURL = "https://api.github.com"
+const (
+	defaultGitHubAPIURL = "https://api.github.com"
+	pemTypePrivateKey   = "PRIVATE KEY"
+)
 
 // GitHubAppTokenResult holds the result of a GitHub App installation token exchange.
 type GitHubAppTokenResult struct {
@@ -95,7 +98,7 @@ func ParseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
 	switch block.Type {
 	case "RSA PRIVATE KEY":
 		return x509.ParsePKCS1PrivateKey(block.Bytes)
-	case "PRIVATE KEY":
+	case pemTypePrivateKey:
 		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
 			return nil, err

--- a/internal/syncengine/plan.go
+++ b/internal/syncengine/plan.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const mappingTypeFile = "file"
+
 // ResolvedMapping is a single source→destination mapping with absolute source
 // and destination-relative target.
 type ResolvedMapping struct {
@@ -63,7 +65,7 @@ func (e *Engine) ExecutePlan(plan *SyncPlan) (*SyncResult, error) {
 	stagedFiles := make(map[string]bool)
 
 	for _, m := range plan.Mappings {
-		if m.Type == "file" {
+		if m.Type == mappingTypeFile {
 			if err := stageSingleFile(m, plan.StagingDir, excludes, stagedFiles, plan.ApplyTemplate); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary

- golangci-lint v2.12.2 (merged via renovate) started enforcing `goconst` violations that were previously not caught
- Add named constants for repeated string literals across 9 files in `agent`, `controller`, `git`, and `syncengine` packages
- Add `ignore-tests: true` to `goconst` settings in `.golangci.yml` to suppress false positives in test files

## Changes

- `internal/agent/metrics.go` - constants for metric namespace (`"stoker"`), subsystem (`"agent"`), and label names
- `internal/agent/agent.go` - constants for `"x-access-token"` and `"default"` profile name
- `internal/controller/metrics.go` - constants for metric namespace, subsystem (`"controller"`), and label names
- `internal/controller/rbac.go` - constants for `"default"` service account and `"app.kubernetes.io/managed-by"` label key
- `internal/controller/gateway_discovery.go` / `gatewaysync_controller.go` - use constants from rbac.go
- `internal/git/client.go` - constant for `"origin"` remote name
- `internal/git/githubapp.go` - constant for `"PRIVATE KEY"` PEM block type
- `internal/syncengine/plan.go` - constant for `"file"` mapping type
- `.golangci.yml` - add `ignore-tests: true` to goconst settings