### PR TITLE
fix: use nodeSelector instead of nodeName in gw-pod-not-running test

### DIFF
--- a/test/e2e/gateway-discovery/03-pod-not-running/chainsaw-test.yaml
+++ b/test/e2e/gateway-discovery/03-pod-not-running/chainsaw-test.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   description: >
     A pod with stoker.io/cr-name but not in Running phase (e.g. Pending due to
-    unschedulable nodeName) should NOT appear in discoveredGateways.
+    unschedulable nodeSelector) should NOT appear in discoveredGateways.
   steps:
     - name: deploy git server and api-key secret
       try:
@@ -69,7 +69,8 @@ spec:
                 annotations:
                   stoker.io/cr-name: test-pnr
               spec:
-                nodeName: nonexistent-node
+                nodeSelector:
+                  stoker.io/nonexistent: "true"
                 containers:
                   - name: pause
                     image: registry.k8s.io/pause:3.9


### PR DESCRIPTION
## Summary

- The `gw-pod-not-running` chainsaw test was creating an unschedulable pod using `nodeName: nonexistent-node`
- This directly binds the pod to a node that doesn't exist. On cleanup, Kubernetes waits for kubelet acknowledgment that never arrives, causing the 1-minute cleanup timeout to expire
- Switched to `nodeSelector: {stoker.io/nonexistent: "true"}` which keeps the pod in Pending/Unschedulable without binding it to any node. The control plane can delete it immediately without waiting for a kubelet.

## Test plan

- [ ] E2E CI passes with `gw-pod-not-running` completing cleanup without timeout error