### PR TITLE
fix: controller concurrency and error-path correctness

### DIFF
--- a/internal/controller/backoff_test.go
+++ b/internal/controller/backoff_test.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestBackoffDelaySequence pins the documented backoff progression
+// (30s, 60s, 120s, 240s, capped at 5m) so the retry behavior surfaced in
+// status messages stays accurate.
+func TestBackoffDelaySequence(t *testing.T) {
+	r := &GatewaySyncReconciler{}
+	key := types.NamespacedName{Name: "cr", Namespace: "ns"}
+
+	if got := r.backoffDelay(key); got != 30*time.Second {
+		t.Errorf("delay before any failure = %v, want 30s", got)
+	}
+
+	want := []time.Duration{
+		30 * time.Second,
+		60 * time.Second,
+		120 * time.Second,
+		240 * time.Second,
+		5 * time.Minute,
+		5 * time.Minute,
+	}
+	for i, w := range want {
+		r.recordFailure(key)
+		if got := r.backoffDelay(key); got != w {
+			t.Errorf("delay after %d failure(s) = %v, want %v", i+1, got, w)
+		}
+	}
+
+	r.resetBackoff(key)
+	if got := r.backoffDelay(key); got != 30*time.Second {
+		t.Errorf("delay after reset = %v, want 30s", got)
+	}
+}
+
+// TestReconcilerSharedStateConcurrency exercises the backoff and token-cache
+// maps from concurrent goroutines, mirroring MaxConcurrentReconciles > 1 where
+// reconciles for different CRs touch this shared state simultaneously. Run with
+// -race this fails if the mutex guarding the maps is removed.
+func TestReconcilerSharedStateConcurrency(t *testing.T) {
+	r := &GatewaySyncReconciler{}
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := types.NamespacedName{Name: "cr", Namespace: "ns"}
+			cacheKey := "123:456"
+			if n%2 == 0 {
+				key.Name = "other-cr"
+				cacheKey = "789:101"
+			}
+			for range 100 {
+				r.recordFailure(key)
+				_ = r.backoffDelay(key)
+				r.storeGitHubToken(cacheKey, cachedToken{token: "t", expiry: time.Now()})
+				_, _ = r.cachedGitHubToken(cacheKey)
+				r.resetBackoff(key)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/controller/gatewaysync_controller.go
+++ b/internal/controller/gatewaysync_controller.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +66,11 @@ type GatewaySyncReconciler struct {
 	Recorder          record.EventRecorder
 	AutoBindAgentRBAC bool
 
+	// mu guards tokenCache and backoff. Reconcile runs with
+	// MaxConcurrentReconciles > 1, so reconciles for different CRs
+	// mutate these maps concurrently.
+	mu sync.Mutex
+
 	// tokenCache holds GitHub App installation tokens keyed by "appID:installationID".
 	tokenCache map[string]cachedToken
 
@@ -119,6 +125,7 @@ func (r *GatewaySyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if err := r.cleanupOwnedResources(ctx, &gs); err != nil {
 				return ctrl.Result{}, err
 			}
+			r.resetBackoff(req.NamespacedName)
 			controllerutil.RemoveFinalizer(&gs, stokertypes.Finalizer)
 			return ctrl.Result{}, r.Update(ctx, &gs)
 		}
@@ -294,9 +301,9 @@ func (r *GatewaySyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // backoffDelay returns the requeue delay based on consecutive failures.
 // Sequence: 30s, 60s, 120s, 240s, 300s (capped).
 func (r *GatewaySyncReconciler) backoffDelay(key types.NamespacedName) time.Duration {
-	if r.backoff == nil {
-		return 30 * time.Second
-	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	state, ok := r.backoff[key]
 	if !ok || state.failureCount == 0 {
 		return 30 * time.Second
@@ -312,6 +319,9 @@ func (r *GatewaySyncReconciler) backoffDelay(key types.NamespacedName) time.Dura
 }
 
 func (r *GatewaySyncReconciler) recordFailure(key types.NamespacedName) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if r.backoff == nil {
 		r.backoff = make(map[types.NamespacedName]*backoffState)
 	}
@@ -325,9 +335,30 @@ func (r *GatewaySyncReconciler) recordFailure(key types.NamespacedName) {
 }
 
 func (r *GatewaySyncReconciler) resetBackoff(key types.NamespacedName) {
-	if r.backoff != nil {
-		delete(r.backoff, key)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.backoff, key)
+}
+
+// cachedGitHubToken returns the cached GitHub App token for a cache key, if present.
+func (r *GatewaySyncReconciler) cachedGitHubToken(cacheKey string) (cachedToken, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cached, ok := r.tokenCache[cacheKey]
+	return cached, ok
+}
+
+// storeGitHubToken caches a GitHub App installation token.
+func (r *GatewaySyncReconciler) storeGitHubToken(cacheKey string, token cachedToken) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.tokenCache == nil {
+		r.tokenCache = make(map[string]cachedToken)
 	}
+	r.tokenCache[cacheKey] = token
 }
 
 // validVarKey matches Go identifiers: letters, digits, underscores; must start with letter or underscore.
@@ -506,7 +537,7 @@ func (r *GatewaySyncReconciler) resolveGitHubAppToken(ctx context.Context, gs *s
 	cacheKey := fmt.Sprintf("%d:%d", appAuth.AppID, appAuth.InstallationID)
 
 	// Return cached token if still valid.
-	if cached, ok := r.tokenCache[cacheKey]; ok && time.Now().Before(cached.expiry.Add(-tokenRefreshBuffer)) {
+	if cached, ok := r.cachedGitHubToken(cacheKey); ok && time.Now().Before(cached.expiry.Add(-tokenRefreshBuffer)) {
 		return cached.token, nil
 	}
 
@@ -527,10 +558,7 @@ func (r *GatewaySyncReconciler) resolveGitHubAppToken(ctx context.Context, gs *s
 	}
 
 	// Cache the token.
-	if r.tokenCache == nil {
-		r.tokenCache = make(map[string]cachedToken)
-	}
-	r.tokenCache[cacheKey] = cachedToken{token: result.Token, expiry: result.ExpiresAt}
+	r.storeGitHubToken(cacheKey, cachedToken{token: result.Token, expiry: result.ExpiresAt})
 
 	githubAppTokenExpiry.WithLabelValues(
 		fmt.Sprintf("%d", appAuth.AppID),
@@ -659,7 +687,7 @@ func (r *GatewaySyncReconciler) ensureMetadataConfigMap(ctx context.Context, gs 
 	if gs.Spec.Git.Auth != nil && gs.Spec.Git.Auth.GitHubApp != nil {
 		appAuth := gs.Spec.Git.Auth.GitHubApp
 		cacheKey := fmt.Sprintf("%d:%d", appAuth.AppID, appAuth.InstallationID)
-		if cached, ok := r.tokenCache[cacheKey]; ok {
+		if cached, ok := r.cachedGitHubToken(cacheKey); ok {
 			if err := r.ensureGitHubTokenSecret(ctx, gs, cached.token); err != nil {
 				return fmt.Errorf("ensuring GitHub App token Secret: %w", err)
 			}
@@ -829,7 +857,7 @@ func (r *GatewaySyncReconciler) requeueInterval(gs *stokerv1alpha1.GatewaySync) 
 	if gs.Spec.Git.Auth != nil && gs.Spec.Git.Auth.GitHubApp != nil {
 		appAuth := gs.Spec.Git.Auth.GitHubApp
 		cacheKey := fmt.Sprintf("%d:%d", appAuth.AppID, appAuth.InstallationID)
-		if cached, ok := r.tokenCache[cacheKey]; ok {
+		if cached, ok := r.cachedGitHubToken(cacheKey); ok {
 			tokenRefresh := time.Until(cached.expiry) - tokenRefreshBuffer
 			if tokenRefresh > 0 && (interval == 0 || tokenRefresh < interval) {
 				interval = tokenRefresh

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -41,7 +41,12 @@ func (r *GatewaySyncReconciler) ensureAgentRoleBinding(ctx context.Context, gs *
 	// Collect unique ServiceAccount names from ALL pods that reference this CR,
 	// regardless of pod phase. This avoids the chicken-and-egg problem where pods
 	// are stuck in Init waiting for RBAC but we only grant RBAC to Running pods.
-	saNames := r.collectServiceAccountsFromPods(ctx, gs)
+	// A List failure must abort: falling through would rewrite the RoleBinding
+	// subjects to the "default" baseline, revoking RBAC from live agents.
+	saNames, err := r.collectServiceAccountsFromPods(ctx, gs)
+	if err != nil {
+		return err
+	}
 	if len(saNames) == 0 {
 		// No matching pods exist yet — use "default" as a baseline subject.
 		saNames = []string{defaultServiceAccount}
@@ -55,7 +60,7 @@ func (r *GatewaySyncReconciler) ensureAgentRoleBinding(ctx context.Context, gs *
 
 	// Try to get existing RoleBinding.
 	existing := &rbacv1.RoleBinding{}
-	err := r.Get(ctx, key, existing)
+	err = r.Get(ctx, key, existing)
 
 	if errors.IsNotFound(err) {
 		// Create new RoleBinding.
@@ -118,10 +123,10 @@ func (r *GatewaySyncReconciler) ensureAgentRoleBinding(ctx context.Context, gs *
 // (via stoker.io/cr-name annotation) regardless of phase, and returns their unique SA names.
 // This is critical: pods may be in Init/Pending state waiting for RBAC before they can reach
 // Running phase, so we must grant RBAC based on ALL matching pods, not just Running ones.
-func (r *GatewaySyncReconciler) collectServiceAccountsFromPods(ctx context.Context, gs *stokerv1alpha1.GatewaySync) []string {
+func (r *GatewaySyncReconciler) collectServiceAccountsFromPods(ctx context.Context, gs *stokerv1alpha1.GatewaySync) ([]string, error) {
 	var podList corev1.PodList
 	if err := r.List(ctx, &podList, client.InNamespace(gs.Namespace)); err != nil {
-		return nil
+		return nil, fmt.Errorf("listing pods for RBAC subjects: %w", err)
 	}
 
 	seen := make(map[string]bool)
@@ -142,7 +147,7 @@ func (r *GatewaySyncReconciler) collectServiceAccountsFromPods(ctx context.Conte
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	return names
+	return names, nil
 }
 
 // buildSubjects creates RoleBinding subjects for the given ServiceAccount names.

--- a/internal/controller/rbac_test.go
+++ b/internal/controller/rbac_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	stokerv1alpha1 "github.com/ia-eknorr/stoker-operator/api/v1alpha1"
+)
+
+// TestEnsureAgentRoleBindingPreservesSubjectsOnListError guards against a
+// regression where a transient pod List failure was swallowed, causing the
+// RoleBinding subjects to be rewritten to the "default" baseline and revoking
+// RBAC from live agents mid-flight.
+func TestEnsureAgentRoleBindingPreservesSubjectsOnListError(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("adding core scheme: %v", err)
+	}
+	if err := stokerv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("adding stoker scheme: %v", err)
+	}
+
+	gs := &stokerv1alpha1.GatewaySync{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cr", Namespace: "test-ns"},
+	}
+	existing := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: agentRoleBindingName(gs.Name), Namespace: gs.Namespace},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     agentClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "gateway-sa", Namespace: gs.Namespace},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gs, existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.PodList); ok {
+					return fmt.Errorf("transient apiserver error")
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	r := &GatewaySyncReconciler{Client: c, Scheme: s}
+
+	if err := r.ensureAgentRoleBinding(context.Background(), gs); err == nil {
+		t.Fatal("expected error when pod List fails, got nil")
+	}
+
+	var rb rbacv1.RoleBinding
+	key := types.NamespacedName{Name: agentRoleBindingName(gs.Name), Namespace: gs.Namespace}
+	if err := c.Get(context.Background(), key, &rb); err != nil {
+		t.Fatalf("getting RoleBinding: %v", err)
+	}
+	if len(rb.Subjects) != 1 || rb.Subjects[0].Name != "gateway-sa" {
+		t.Errorf("RoleBinding subjects were modified despite List error: %+v", rb.Subjects)
+	}
+}

--- a/internal/git/githubapp.go
+++ b/internal/git/githubapp.go
@@ -25,6 +25,11 @@ type GitHubAppTokenResult struct {
 	ExpiresAt time.Time
 }
 
+// githubHTTPClient bounds the token exchange. The reconcile context carries no
+// deadline of its own, so a hung GitHub API call would otherwise block a
+// reconcile worker indefinitely.
+var githubHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 // ExchangeGitHubAppToken exchanges a GitHub App PEM private key for a short-lived
 // installation access token. It signs a JWT (RS256, 10-minute expiry), then POSTs
 // to the GitHub installations API to obtain a 1-hour bearer token.
@@ -58,7 +63,7 @@ func ExchangeGitHubAppToken(ctx context.Context, pemBytes []byte, appID, install
 	req.Header.Set("Authorization", "Bearer "+jwtStr)
 	req.Header.Set("Accept", "application/vnd.github+json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := githubHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("exchanging token: %w", err)
 	}


### PR DESCRIPTION
### 📖 Background

The reconciler runs with `MaxConcurrentReconciles: 5`. controller-runtime serializes reconciles per object but not across objects, so two GatewaySync CRs reconciling at the same time share the reconciler's `tokenCache` and `backoff` maps. Plain Go maps are not safe for concurrent mutation: two CRs failing ref resolution simultaneously can panic the whole controller with a concurrent map write. While auditing those paths, two adjacent error-handling gaps surfaced.

### ⚙️ Changes

- Guard `tokenCache` and `backoff` with a mutex (small critical sections via accessor helpers), and drop a CR's backoff entry on deletion so the map doesn't grow unbounded across CR churn.
- `ensureAgentRoleBinding` now aborts when the pod List fails instead of swallowing the error. Previously a transient apiserver error produced an empty ServiceAccount list, which rewrote the RoleBinding subjects to the `default` baseline and revoked RBAC from live agents until a later reconcile repaired it.
- The GitHub App token exchange used `http.DefaultClient`, which has no timeout, under a reconcile context with no deadline; a hung GitHub API call would pin a reconcile worker forever. It now uses a 30s-timeout client.

### 📝 Reviewer Notes

`resolveGitHubAppToken` intentionally does not hold the lock across the HTTP exchange; two CRs sharing one installation may both exchange a token in a race, which is harmless (last write wins, both tokens valid).

### ☑️ Testing Notes

- `TestReconcilerSharedStateConcurrency` exercises the maps from 8 goroutines; fails under `-race` without the mutex.
- `TestEnsureAgentRoleBindingPreservesSubjectsOnListError` pins the RBAC regression with an interceptor fake client.
- `TestBackoffDelaySequence` pins the documented 30s→5m progression.
- `make build`, `make lint`, `make test` green; full Chainsaw e2e suite passes 41/41 on this branch.