### PR TITLE
docs: correct controller-agent communication and auth descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,10 @@ go test ./internal/syncengine/ -run TestBuildPlan -v
 ### Controller ↔ Agent Communication
 
 No shared PVC. Communication is entirely via ConfigMaps:
-- `stoker-metadata-{crName}` — controller writes git URL, commit, ref, auth type, excludes
+- `stoker-metadata-{crName}` — controller writes commit, ref, git URL, auth type, paused flag, resolved profiles JSON, gateway port/TLS
 - `stoker-status-{crName}` — agent writes sync status per gateway
-- `stoker-changes-{crName}` — agent writes change details
+
+(`stoker-changes-{crName}` is a legacy name still removed during finalizer cleanup; nothing writes it.)
 
 ### Agent 3-Layer Architecture
 
@@ -70,7 +71,7 @@ Mutating webhook at `/mutate-v1-pod` injects the agent as a native sidecar (`ini
 1. Namespace label: `stoker.io/injection=enabled`
 2. Pod annotation: `stoker.io/inject: "true"`
 
-Agent image is resolved 3-tier: pod annotation > CR `spec.agent.image` > env `DEFAULT_AGENT_IMAGE`.
+Agent image is resolved 2-tier: CR `spec.agent.image` > env `DEFAULT_AGENT_IMAGE` (the pod-annotation tier was removed in v0.6.0).
 
 ### Webhook Receiver
 
@@ -82,7 +83,7 @@ HTTP server on port 9444 (`POST /webhook/{namespace}/{crName}`). Auto-detects pa
 - **Finalizer:** `stoker.io/finalizer`
 - **Status patches:** Uses `client.MergeFrom()` to avoid resourceVersion conflicts
 - **Predicate filter:** Controller watches GatewaySync CRs with a custom predicate that passes on generation change OR annotation change (for webhook-triggered reconciles)
-- **Git auth:** Controller resolves secrets for `ls-remote`; agent reads from hardcoded mount paths `/etc/stoker/git-credentials` and `/etc/stoker/api-key`. For GitHub App auth, the controller exchanges the PEM for an installation token, caches it, and writes it to the metadata ConfigMap — agent reads the token from the ConfigMap (PEM never mounted into agent pods).
+- **Git auth:** Controller resolves secrets for `ls-remote`; agent reads from hardcoded mount paths `/etc/stoker/git-credentials` and `/etc/stoker/api-key`. For GitHub App auth, the controller exchanges the PEM for an installation token, caches it, and writes it to the Secret `stoker-github-token-{crName}`, which the webhook mounts into the agent at `/etc/stoker/git-token/token` (PEM never mounted into agent pods).
 
 ## Code Generation Workflow
 

--- a/docs/docs/overview/architecture.md
+++ b/docs/docs/overview/architecture.md
@@ -88,11 +88,11 @@ The sync engine is intentionally Kubernetes-unaware and Ignition-unaware, making
 
 ## Communication via ConfigMaps
 
-The controller and agents never communicate directly. All state flows through three ConfigMaps per CR:
+The controller and agents never communicate directly. All state flows through two ConfigMaps per CR:
 
 | ConfigMap | Writer | Reader | Contents |
 |-----------|--------|--------|----------|
-| `stoker-metadata-{crName}` | Controller | Agent | Git URL, resolved commit, ref, auth type, exclude patterns, profile mappings |
+| `stoker-metadata-{crName}` | Controller | Agent | Git URL, resolved commit, ref, auth type, paused flag, resolved profiles (mappings, excludes, vars) |
 | `stoker-status-{crName}` | Agent | Controller | Per-gateway sync status, synced commit, file counts, errors, change details |
 
 This design means no shared PVC is needed, and agents can run in any pod without special volume configuration beyond the standard `/ignition-data/` mount.

--- a/pkg/types/annotations.go
+++ b/pkg/types/annotations.go
@@ -20,14 +20,6 @@ const (
 	// If unset, the "default" profile is used.
 	AnnotationProfile = AnnotationPrefix + "/profile"
 
-	// AnnotationRefOverride overrides the git ref for this pod only.
-	// Read by the agent sidecar, NOT the controller. The agent resolves
-	// the ref independently via ls-remote and syncs to that commit instead
-	// of the metadata ConfigMap's ref. The controller detects the skew
-	// (syncedRef != lastSyncRef) and sets a RefSkew warning condition.
-	// Intended for dev/test gateways in production namespaces.
-	AnnotationRefOverride = AnnotationPrefix + "/ref-override"
-
 	// CR annotations — set by the webhook receiver on the GatewaySync CR (not by users).
 
 	// AnnotationRequestedRef is set by the webhook receiver to request a ref update.


### PR DESCRIPTION
### 📖 Background

Several internal docs drifted from the code as the GitHub App token delivery moved to a Secret mount and the agent-image annotation tier was removed in v0.6.0. Stale docs here are actively misleading because CLAUDE.md is loaded as ground truth by coding agents.

### ⚙️ Changes

- CLAUDE.md and `docs/docs/overview/architecture.md`: the metadata ConfigMap does not carry standalone exclude patterns (they travel inside the resolved profiles JSON), and `stoker-changes-{crName}` is not a communication channel — nothing writes it; only finalizer cleanup still removes the legacy name.
- CLAUDE.md: GitHub App installation tokens are written to the `stoker-github-token-{crName}` Secret and mounted at `/etc/stoker/git-token/token`, not delivered via the metadata ConfigMap.
- CLAUDE.md: agent image resolution is 2-tier (CR field > `DEFAULT_AGENT_IMAGE`) since v0.6.0.
- Remove the unused `AnnotationRefOverride` constant: its godoc described agent-side ref override behavior and a RefSkew condition that were never implemented. The roadmap still tracks the feature.

### 📝 Reviewer Notes

`grep -rn 'ref-override\|gitToken\|stoker-changes' --include='*.go'` confirms none of the removed claims have code behind them.

### ☑️ Testing Notes

Docs-only plus an unused-constant removal; `go build ./...` and `make lint` pass.