### PR TITLE
fix: agent startup, sync serialization, and atomic writes

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,15 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/go-git/go-git/v5/plumbing/transport"
-	gogithttp "github.com/go-git/go-git/v5/plumbing/transport/http"
-	gogitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-logr/logr"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,10 +25,7 @@ import (
 	stokertypes "github.com/ia-eknorr/stoker-operator/pkg/types"
 )
 
-const (
-	gitAccessTokenUser = "x-access-token"
-	defaultProfileName = "default"
-)
+const defaultProfileName = "default"
 
 // agentVersion is set at build time via ldflags. Falls back to "dev" for local builds.
 var agentVersion = "dev"
@@ -64,6 +57,12 @@ type Agent struct {
 	// Exponential backoff for consecutive sync failures.
 	consecutiveErrors int
 	backoffUntil      time.Time
+
+	// syncMu serializes sync cycles. The post-commission goroutine and the
+	// watcher loop share one staging directory; concurrent ExecutePlan calls
+	// would delete it out from under each other mid-merge. It also guards
+	// lastSyncedCommit and lastSyncedProfiles.
+	syncMu sync.Mutex
 
 	// Graceful shutdown: track in-flight syncs.
 	syncInProgress atomic.Bool
@@ -129,19 +128,18 @@ func (a *Agent) Run(ctx context.Context) error {
 	// Cache GatewaySync CR reference for event emission.
 	a.fetchCRRef(ctx)
 
-	// Resolve git auth from mounted files or metadata ConfigMap (GitHub App).
-	auth := a.resolveAuth(meta)
-
 	// Use git URL from metadata ConfigMap, fall back to empty (shouldn't happen).
 	gitURL := meta.GitURL
 	if gitURL == "" {
 		return fmt.Errorf("gitURL not found in metadata ConfigMap")
 	}
 
-	// Initial clone.
+	// Initial clone. Git auth comes from mounted credential files via
+	// GIT_SSH_KEY_FILE / GIT_TOKEN_FILE env vars, read fresh on every git
+	// operation so rotated Secrets are picked up without a restart.
 	log.Info("cloning repository", "url", gitURL, "ref", meta.Ref)
 	cloneStart := time.Now()
-	result, err := a.GitClient.CloneOrFetch(ctx, gitURL, meta.Ref, a.Config.RepoPath, auth)
+	result, err := a.GitClient.CloneOrFetch(ctx, gitURL, meta.Ref, a.Config.RepoPath, nil)
 	a.Metrics.GitFetchDuration.WithLabelValues("clone").Observe(time.Since(cloneStart).Seconds())
 	if err != nil {
 		a.Metrics.GitFetchTotal.WithLabelValues("clone", "error").Inc()
@@ -201,7 +199,7 @@ func (a *Agent) Run(ctx context.Context) error {
 
 		case <-a.Watcher.Events():
 			log.V(1).Info("sync triggered")
-			a.handleSyncTrigger(ctx, gitURL, auth)
+			a.handleSyncTrigger(ctx, gitURL)
 		}
 	}
 }
@@ -233,7 +231,10 @@ func (a *Agent) postCommissionSync(ctx context.Context, commit, ref string) {
 
 		a.Metrics.GatewayStartupDuration.Observe(time.Since(startupStart).Seconds())
 		log.Info("gateway responsive, running post-commission re-sync")
-		if err := a.syncOnce(ctx, commit, ref, false, a.lastSyncedProfiles); err != nil {
+		a.syncMu.Lock()
+		err := a.syncOnce(ctx, commit, ref, false, a.lastSyncedProfiles)
+		a.syncMu.Unlock()
+		if err != nil {
 			log.Error(err, "post-commission sync failed")
 		} else {
 			log.Info("post-commission sync complete")
@@ -274,7 +275,7 @@ func (a *Agent) waitForMetadata(ctx context.Context) (*Metadata, error) {
 }
 
 // handleSyncTrigger reads the latest metadata and performs a sync if needed.
-func (a *Agent) handleSyncTrigger(ctx context.Context, gitURL string, auth transport.AuthMethod) {
+func (a *Agent) handleSyncTrigger(ctx context.Context, gitURL string) {
 	log := logf.FromContext(ctx).WithName("sync")
 
 	// Check backoff before doing any work.
@@ -296,13 +297,8 @@ func (a *Agent) handleSyncTrigger(ctx context.Context, gitURL string, auth trans
 		return
 	}
 
-	// Refresh auth from metadata if GitHub App token was updated by controller.
-	if meta.GitToken != "" {
-		auth = &gogithttp.BasicAuth{
-			Username: gitAccessTokenUser,
-			Password: meta.GitToken,
-		}
-	}
+	a.syncMu.Lock()
+	defer a.syncMu.Unlock()
 
 	// Check if commit or profiles changed.
 	if meta.Commit == a.lastSyncedCommit && meta.Profiles == a.lastSyncedProfiles {
@@ -332,7 +328,7 @@ func (a *Agent) handleSyncTrigger(ctx context.Context, gitURL string, auth trans
 
 	// Fetch and checkout new commit.
 	fetchStart := time.Now()
-	result, err := a.GitClient.CloneOrFetch(syncCtx, gitURL, meta.Ref, a.Config.RepoPath, auth)
+	result, err := a.GitClient.CloneOrFetch(syncCtx, gitURL, meta.Ref, a.Config.RepoPath, nil)
 	a.Metrics.GitFetchDuration.WithLabelValues("fetch").Observe(time.Since(fetchStart).Seconds())
 	if err != nil {
 		a.Metrics.GitFetchTotal.WithLabelValues("fetch", "error").Inc()
@@ -754,53 +750,4 @@ func (a *Agent) fetchCRRef(ctx context.Context) {
 // isForbidden checks if an error (possibly wrapped) is a Kubernetes 403 Forbidden.
 func isForbidden(err error) bool {
 	return apierrors.IsForbidden(err) || apierrors.ReasonForError(err) == metav1.StatusReasonForbidden
-}
-
-// resolveAuth builds a go-git transport.AuthMethod from mounted credential files
-// or from the metadata ConfigMap (GitHub App tokens delivered by controller).
-func (a *Agent) resolveAuth(meta *Metadata) transport.AuthMethod {
-	// File-based auth takes priority (SSH key, token).
-	if auth := a.resolveFileAuth(); auth != nil {
-		return auth
-	}
-
-	// GitHub App: token delivered via metadata ConfigMap.
-	if meta != nil && meta.GitToken != "" {
-		return &gogithttp.BasicAuth{
-			Username: gitAccessTokenUser,
-			Password: meta.GitToken,
-		}
-	}
-
-	return nil
-}
-
-// resolveFileAuth builds a go-git transport.AuthMethod from mounted credential files.
-func (a *Agent) resolveFileAuth() transport.AuthMethod {
-	// SSH key takes priority.
-	if sshKey := a.Config.GitSSHKey(); len(sshKey) > 0 {
-		publicKey, err := gogitssh.NewPublicKeys("git", sshKey, "")
-		if err == nil {
-			if a.Config.GitKnownHostsFile != "" {
-				if hostKeyCallback, khErr := knownhosts.New(a.Config.GitKnownHostsFile); khErr == nil {
-					publicKey.HostKeyCallback = hostKeyCallback
-				} else {
-					publicKey.HostKeyCallback = ssh.InsecureIgnoreHostKey()
-				}
-			} else {
-				publicKey.HostKeyCallback = ssh.InsecureIgnoreHostKey()
-			}
-			return publicKey
-		}
-	}
-
-	// Token auth.
-	if token := a.Config.GitToken(); token != "" {
-		return &gogithttp.BasicAuth{
-			Username: gitAccessTokenUser,
-			Password: token,
-		}
-	}
-
-	return nil
 }

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -7,41 +7,38 @@ import (
 	"strings"
 )
 
-// Config holds the agent runtime configuration loaded from env vars and mounted files.
+// Config holds the agent runtime configuration loaded from env vars and mounted
+// files. Git credentials are not held here: the git client reads the
+// GIT_SSH_KEY_FILE / GIT_TOKEN_FILE / GIT_KNOWN_HOSTS_FILE env vars directly on
+// every operation so rotated Secrets are picked up without a restart.
 type Config struct {
-	PodName           string
-	PodNamespace      string
-	GatewayName       string
-	CRName            string
-	CRNamespace       string
-	RepoPath          string
-	DataPath          string
-	GatewayPort       string
-	GatewayTLS        bool
-	APIKeyFile        string
-	SyncPeriod        int // seconds
-	GitTokenFile      string
-	GitSSHKeyFile     string
-	GitKnownHostsFile string
-	ProfileName       string // profile name from embedded spec.sync.profiles
+	PodName      string
+	PodNamespace string
+	GatewayName  string
+	CRName       string
+	CRNamespace  string
+	RepoPath     string
+	DataPath     string
+	GatewayPort  string
+	GatewayTLS   bool
+	APIKeyFile   string
+	SyncPeriod   int    // seconds
+	ProfileName  string // profile name from embedded spec.sync.profiles
 }
 
 // LoadConfig reads agent configuration from environment variables.
 func LoadConfig() (*Config, error) {
 	cfg := &Config{
-		PodName:           os.Getenv("POD_NAME"),
-		PodNamespace:      os.Getenv("POD_NAMESPACE"),
-		GatewayName:       os.Getenv("GATEWAY_NAME"),
-		CRName:            os.Getenv("CR_NAME"),
-		CRNamespace:       os.Getenv("CR_NAMESPACE"),
-		RepoPath:          os.Getenv("REPO_PATH"),
-		DataPath:          os.Getenv("DATA_PATH"),
-		GatewayPort:       os.Getenv("GATEWAY_PORT"),
-		APIKeyFile:        os.Getenv("API_KEY_FILE"),
-		GitTokenFile:      os.Getenv("GIT_TOKEN_FILE"),
-		GitSSHKeyFile:     os.Getenv("GIT_SSH_KEY_FILE"),
-		GitKnownHostsFile: os.Getenv("GIT_KNOWN_HOSTS_FILE"),
-		ProfileName:       os.Getenv("PROFILE"),
+		PodName:      os.Getenv("POD_NAME"),
+		PodNamespace: os.Getenv("POD_NAMESPACE"),
+		GatewayName:  os.Getenv("GATEWAY_NAME"),
+		CRName:       os.Getenv("CR_NAME"),
+		CRNamespace:  os.Getenv("CR_NAMESPACE"),
+		RepoPath:     os.Getenv("REPO_PATH"),
+		DataPath:     os.Getenv("DATA_PATH"),
+		GatewayPort:  os.Getenv("GATEWAY_PORT"),
+		APIKeyFile:   os.Getenv("API_KEY_FILE"),
+		ProfileName:  os.Getenv("PROFILE"),
 	}
 
 	// Defaults
@@ -72,15 +69,14 @@ func LoadConfig() (*Config, error) {
 		}
 	}
 
-	// Validate required fields
+	// Validate required fields. ProfileName may be empty: pods without a
+	// stoker.io/profile annotation fall back to the "default" profile at
+	// lookup time, per the CRD contract.
 	if cfg.CRName == "" {
 		return nil, fmt.Errorf("CR_NAME env var is required")
 	}
 	if cfg.PodNamespace == "" {
 		return nil, fmt.Errorf("POD_NAMESPACE env var is required")
-	}
-	if cfg.ProfileName == "" {
-		return nil, fmt.Errorf("PROFILE env var is required")
 	}
 
 	return cfg, nil
@@ -96,30 +92,6 @@ func (c *Config) APIKey() string {
 		return ""
 	}
 	return strings.TrimSpace(string(data))
-}
-
-// GitToken reads the git token from the mounted file.
-func (c *Config) GitToken() string {
-	if c.GitTokenFile == "" {
-		return ""
-	}
-	data, err := os.ReadFile(c.GitTokenFile)
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
-}
-
-// GitSSHKey reads the SSH private key from the mounted file.
-func (c *Config) GitSSHKey() []byte {
-	if c.GitSSHKeyFile == "" {
-		return nil
-	}
-	data, err := os.ReadFile(c.GitSSHKeyFile)
-	if err != nil {
-		return nil
-	}
-	return data
 }
 
 // GatewayScheme returns "https" or "http" based on TLS setting.

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -1,0 +1,36 @@
+package agent
+
+import "testing"
+
+// TestLoadConfigProfileOptional guards the documented fallback: pods without a
+// stoker.io/profile annotation get an empty PROFILE env var, and the agent must
+// start and resolve the "default" profile instead of crash-looping at config load.
+func TestLoadConfigProfileOptional(t *testing.T) {
+	t.Setenv("CR_NAME", "test-cr")
+	t.Setenv("POD_NAMESPACE", "test-ns")
+	t.Setenv("PROFILE", "")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig with empty PROFILE: %v", err)
+	}
+	if cfg.ProfileName != "" {
+		t.Errorf("ProfileName = %q, want empty (lookup falls back to default)", cfg.ProfileName)
+	}
+}
+
+// TestLoadConfigRequiredFields pins the two env vars the agent genuinely cannot
+// run without, so the failure mode stays a clear startup error.
+func TestLoadConfigRequiredFields(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "test-ns")
+	t.Setenv("CR_NAME", "")
+	if _, err := LoadConfig(); err == nil {
+		t.Error("LoadConfig without CR_NAME should fail")
+	}
+
+	t.Setenv("CR_NAME", "test-cr")
+	t.Setenv("POD_NAMESPACE", "")
+	if _, err := LoadConfig(); err == nil {
+		t.Error("LoadConfig without POD_NAMESPACE should fail")
+	}
+}

--- a/internal/agent/configmap.go
+++ b/internal/agent/configmap.go
@@ -27,15 +27,12 @@ func StatusConfigMapName(crName string) string {
 
 // Metadata holds the data read from the metadata ConfigMap.
 type Metadata struct {
-	Commit          string
-	Ref             string
-	Trigger         string
-	GitURL          string
-	Paused          string
-	ExcludePatterns string
-	Profiles        string
-	AuthType        string
-	GitToken        string
+	Commit   string
+	Ref      string
+	GitURL   string
+	Paused   string
+	Profiles string
+	AuthType string
 }
 
 // ReadMetadataConfigMap reads the metadata ConfigMap and returns its data.
@@ -55,15 +52,12 @@ func ReadMetadataConfigMap(ctx context.Context, c client.Client, namespace, crNa
 	}
 
 	return &Metadata{
-		Commit:          cm.Data["commit"],
-		Ref:             cm.Data["ref"],
-		Trigger:         cm.Data["trigger"],
-		GitURL:          cm.Data["gitURL"],
-		Paused:          cm.Data["paused"],
-		ExcludePatterns: cm.Data["excludePatterns"],
-		Profiles:        cm.Data["profiles"],
-		AuthType:        cm.Data["authType"],
-		GitToken:        cm.Data["gitToken"],
+		Commit:   cm.Data["commit"],
+		Ref:      cm.Data["ref"],
+		GitURL:   cm.Data["gitURL"],
+		Paused:   cm.Data["paused"],
+		Profiles: cm.Data["profiles"],
+		AuthType: cm.Data["authType"],
 	}, nil
 }
 

--- a/internal/syncengine/copy.go
+++ b/internal/syncengine/copy.go
@@ -13,6 +13,8 @@ import (
 // Returns true if the file was actually written (new or changed).
 // Symlinks at src are rejected: a malicious repo could symlink to credential
 // mounts or other host paths and have them copied into the destination.
+// The write goes through a temp file in dst's directory followed by rename,
+// so the gateway never observes a truncated file if the agent dies mid-copy.
 func copyFile(src, dst string) (bool, error) {
 	srcInfo, err := os.Lstat(src)
 	if err != nil {
@@ -37,17 +39,28 @@ func copyFile(src, dst string) (bool, error) {
 	}
 	defer func() { _ = in.Close() }()
 
-	out, err := os.Create(dst)
+	out, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+".stoker-tmp-*")
 	if err != nil {
-		return false, fmt.Errorf("creating destination %s: %w", dst, err)
+		return false, fmt.Errorf("creating temp file for %s: %w", dst, err)
 	}
-	defer func() { _ = out.Close() }()
+	tmpName := out.Name()
+	defer func() {
+		_ = out.Close()
+		_ = os.Remove(tmpName) // no-op after successful rename
+	}()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return false, fmt.Errorf("copying %s to %s: %w", src, dst, err)
 	}
-
-	_ = os.Chmod(dst, srcInfo.Mode())
+	if err := out.Close(); err != nil {
+		return false, fmt.Errorf("closing temp file for %s: %w", dst, err)
+	}
+	if err := os.Chmod(tmpName, srcInfo.Mode()); err != nil {
+		return false, fmt.Errorf("setting mode on %s: %w", dst, err)
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		return false, fmt.Errorf("renaming temp file to %s: %w", dst, err)
+	}
 
 	return true, nil
 }

--- a/internal/syncengine/copy_test.go
+++ b/internal/syncengine/copy_test.go
@@ -100,6 +100,54 @@ func TestCopyFile_RejectsSymlinkSource(t *testing.T) {
 	}
 }
 
+// TestCopyFile_AtomicWriteLeavesNoTempFiles guards the temp-file-plus-rename
+// contract: the destination must end up with the source's content and mode,
+// and no scratch files may linger for the gateway's scan to pick up.
+func TestCopyFile_AtomicWriteLeavesNoTempFiles(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src.json")
+	dst := filepath.Join(tmp, "dest", "config.json")
+	writeTestFile(t, src, `{"a":1}`)
+	if err := os.Chmod(src, 0755); err != nil {
+		t.Fatalf("chmod src: %v", err)
+	}
+
+	wrote, err := copyFile(src, dst)
+	if err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	if !wrote {
+		t.Error("copyFile should report a write for a new destination")
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading dst: %v", err)
+	}
+	if string(got) != `{"a":1}` {
+		t.Errorf("dst content = %q, want %q", got, `{"a":1}`)
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("dst mode = %v, want 0755", info.Mode().Perm())
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(dst))
+	if err != nil {
+		t.Fatalf("reading dst dir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("temp files left behind in destination dir: %v", names)
+	}
+}
+
 func TestFilesEqual_MissingFile(t *testing.T) {
 	tmp := t.TempDir()
 	a := filepath.Join(tmp, "exists.txt")


### PR DESCRIPTION
### 📖 Background

Three agent-side correctness issues found while auditing the sync loop end to end:

1. The CRD documents that pods without a `stoker.io/profile` annotation fall back to the `default` profile, and `lookupProfile` implements exactly that — but the agent never got there. The webhook always injects the `PROFILE` env var (empty when the annotation is absent), and `LoadConfig` treated empty as a fatal error, so such pods crash-looped at startup.
2. The post-commission re-sync goroutine and the watcher loop both call `syncOnce` with no coordination. They share one staging directory, and `ExecutePlan` starts by `os.RemoveAll`-ing it: a watcher-triggered sync landing during the post-commission window could delete staging out from under the other sync mid-merge (plus a data race on `lastSyncedCommit`/`lastSyncedProfiles`).
3. `copyFile` wrote live files with `os.Create`, which truncates in place. An agent killed mid-copy left a truncated config file in the live directory for the gateway's scan to pick up.

### ⚙️ Changes

- `LoadConfig` accepts an empty `PROFILE`; the existing default-profile fallback at lookup time now actually engages.
- A `syncMu` mutex serializes sync cycles between the watcher loop and the post-commission goroutine.
- Live-file writes go through a temp file in the destination directory plus rename, so the gateway never observes partial content.
- Removed the agent's dead go-git auth resolution: the agent's `NativeGitClient` ignores the `transport.AuthMethod` argument and reads `GIT_SSH_KEY_FILE`/`GIT_TOKEN_FILE` fresh per operation, and the `gitToken` ConfigMap refresh path read a key the controller stopped writing when GitHub App tokens moved to the `stoker-github-token` Secret. The code implied a token-delivery path that doesn't exist.

### 📝 Reviewer Notes

The auth removal is behavior-preserving: every credential source the deleted code handled is already handled (more freshly) by `buildGitEnv` in `internal/git/client.go` at each clone/fetch. `Metadata` loses only fields (`trigger`, `excludePatterns`, `gitToken`) the controller never writes.

### ☑️ Testing Notes

- `TestLoadConfigProfileOptional` pins the crash-loop regression; `TestCopyFile_AtomicWriteLeavesNoTempFiles` pins the temp-file-plus-rename contract including mode preservation.
- `make build`, `make lint`, unit tests green; full Chainsaw e2e suite passes 41/41 with this branch's agent image.