### PR TITLE
fix: commit SHA refs and credential handling in native git client

### DIFF
--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -257,9 +257,9 @@ func (g *NativeGitClient) CloneOrFetch(ctx context.Context, repoURL, ref, path s
 	defer cleanup()
 
 	if isCloned(path) {
-		return nativeFetchAndCheckout(ctx, authURL, ref, path, env)
+		return nativeFetchAndCheckout(ctx, repoURL, authURL, ref, path, env)
 	}
-	return nativeCloneAndCheckout(ctx, authURL, ref, path, env)
+	return nativeCloneAndCheckout(ctx, repoURL, authURL, ref, path, env)
 }
 
 // buildGitEnv prepares environment variables for native git commands.
@@ -348,7 +348,10 @@ func injectTokenIntoURL(repoURL, token string) string {
 	return repoURL
 }
 
-func nativeCloneAndCheckout(ctx context.Context, repoURL, ref, path string, env []string) (Result, error) {
+// nativeCloneAndCheckout performs the initial clone. cleanURL is what gets
+// persisted as the origin remote; authURL (which may embed a token) is only
+// ever passed on the command line so credentials never land in .git/config.
+func nativeCloneAndCheckout(ctx context.Context, cleanURL, authURL, ref, path string, env []string) (Result, error) {
 	// `git clone --branch` only accepts branch and tag names. For a commit
 	// SHA, init an empty repo and reuse the fetch path, which fetches the
 	// SHA directly (supported by GitHub/GitLab via allow-reachable-SHA1).
@@ -356,24 +359,29 @@ func nativeCloneAndCheckout(ctx context.Context, repoURL, ref, path string, env 
 		if _, err := runGit(ctx, []string{"init", path}, "", env); err != nil {
 			return Result{}, fmt.Errorf("git init: %w", err)
 		}
-		if _, err := runGit(ctx, []string{"remote", "add", gitRemoteOrigin, repoURL}, path, env); err != nil {
+		if _, err := runGit(ctx, []string{"remote", "add", gitRemoteOrigin, cleanURL}, path, env); err != nil {
 			return Result{}, fmt.Errorf("git remote add: %w", err)
 		}
-		return nativeFetchAndCheckout(ctx, repoURL, ref, path, env)
+		return nativeFetchAndCheckout(ctx, cleanURL, authURL, ref, path, env)
 	}
 
-	if _, err := runGit(ctx, []string{"clone", "--depth=1", "--branch", ref, repoURL, path}, "", env); err != nil {
+	if _, err := runGit(ctx, []string{"clone", "--depth=1", "--branch", ref, authURL, path}, "", env); err != nil {
 		return Result{}, fmt.Errorf("git clone --branch %s: %w", ref, err)
+	}
+	// Replace the persisted origin URL with the credential-free form.
+	if _, err := runGit(ctx, []string{"remote", "set-url", gitRemoteOrigin, cleanURL}, path, env); err != nil {
+		return Result{}, fmt.Errorf("git remote set-url: %w", err)
 	}
 	return nativeRevParse(ctx, ref, path, env)
 }
 
-func nativeFetchAndCheckout(ctx context.Context, repoURL, ref, path string, env []string) (Result, error) {
-	// Update remote URL in case it changed in the CR spec.
-	if _, err := runGit(ctx, []string{"remote", "set-url", gitRemoteOrigin, repoURL}, path, env); err != nil {
+func nativeFetchAndCheckout(ctx context.Context, cleanURL, authURL, ref, path string, env []string) (Result, error) {
+	// Keep the persisted remote URL current with the CR spec (credential-free);
+	// the fetch itself uses the auth URL directly so the token stays off disk.
+	if _, err := runGit(ctx, []string{"remote", "set-url", gitRemoteOrigin, cleanURL}, path, env); err != nil {
 		return Result{}, fmt.Errorf("git remote set-url: %w", err)
 	}
-	if _, err := runGit(ctx, []string{"fetch", "--depth=1", gitRemoteOrigin, ref}, path, env); err != nil {
+	if _, err := runGit(ctx, []string{"fetch", "--depth=1", authURL, ref}, path, env); err != nil {
 		return Result{}, fmt.Errorf("git fetch: %w", err)
 	}
 	if _, err := runGit(ctx, []string{"checkout", "-f", "FETCH_HEAD"}, path, env); err != nil {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -349,6 +349,19 @@ func injectTokenIntoURL(repoURL, token string) string {
 }
 
 func nativeCloneAndCheckout(ctx context.Context, repoURL, ref, path string, env []string) (Result, error) {
+	// `git clone --branch` only accepts branch and tag names. For a commit
+	// SHA, init an empty repo and reuse the fetch path, which fetches the
+	// SHA directly (supported by GitHub/GitLab via allow-reachable-SHA1).
+	if plumbing.IsHash(ref) {
+		if _, err := runGit(ctx, []string{"init", path}, "", env); err != nil {
+			return Result{}, fmt.Errorf("git init: %w", err)
+		}
+		if _, err := runGit(ctx, []string{"remote", "add", gitRemoteOrigin, repoURL}, path, env); err != nil {
+			return Result{}, fmt.Errorf("git remote add: %w", err)
+		}
+		return nativeFetchAndCheckout(ctx, repoURL, ref, path, env)
+	}
+
 	if _, err := runGit(ctx, []string{"clone", "--depth=1", "--branch", ref, repoURL, path}, "", env); err != nil {
 		return Result{}, fmt.Errorf("git clone --branch %s: %w", ref, err)
 	}
@@ -386,7 +399,13 @@ func runGit(ctx context.Context, args []string, dir string, extraEnv []string) (
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%s", sanitizeOutput(string(out)))
+		msg := sanitizeOutput(string(out))
+		if msg == "" {
+			// No command output (e.g. binary missing, signal kill) — surface
+			// the exec error itself rather than an empty message.
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("%s", msg)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/git/native_client_test.go
+++ b/internal/git/native_client_test.go
@@ -1,0 +1,134 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initFixtureRepo creates a local git repo with two commits and returns the
+// repo path plus both commit SHAs (first, second). allowReachableSHA1InWant is
+// enabled so SHA fetches over the file/local transport behave like GitHub.
+func initFixtureRepo(t *testing.T) (repoPath, firstSHA, secondSHA string) {
+	t.Helper()
+	repoPath = filepath.Join(t.TempDir(), "fixture")
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoPath
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	if err := os.MkdirAll(repoPath, 0755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+	run("init", "--initial-branch=main")
+	run("config", "uploadpack.allowReachableSHA1InWant", "true")
+
+	if err := os.WriteFile(filepath.Join(repoPath, "a.txt"), []byte("one"), 0644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	run("add", ".")
+	run("commit", "-m", "first")
+	firstSHA = run("rev-parse", "HEAD")
+
+	if err := os.WriteFile(filepath.Join(repoPath, "a.txt"), []byte("two"), 0644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	run("add", ".")
+	run("commit", "-m", "second")
+	secondSHA = run("rev-parse", "HEAD")
+
+	return repoPath, firstSHA, secondSHA
+}
+
+// TestNativeCloneCommitSHA covers the CRD's promise that spec.git.ref may be a
+// commit SHA: `git clone --branch <sha>` is invalid, so the initial clone must
+// take the init+fetch path instead of failing permanently.
+func TestNativeCloneCommitSHA(t *testing.T) {
+	t.Setenv("GIT_SSH_KEY_FILE", "")
+	t.Setenv("GIT_TOKEN_FILE", "")
+
+	repoPath, firstSHA, _ := initFixtureRepo(t)
+	dst := filepath.Join(t.TempDir(), "clone")
+
+	client := &NativeGitClient{}
+	result, err := client.CloneOrFetch(context.Background(), repoPath, firstSHA, dst, nil)
+	if err != nil {
+		t.Fatalf("CloneOrFetch with SHA ref: %v", err)
+	}
+	if result.Commit != firstSHA {
+		t.Errorf("checked-out commit = %s, want %s", result.Commit, firstSHA)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dst, "a.txt"))
+	if err != nil {
+		t.Fatalf("reading synced file: %v", err)
+	}
+	if string(content) != "one" {
+		t.Errorf("a.txt = %q, want %q (content of first commit)", content, "one")
+	}
+}
+
+// TestNativeFetchCommitSHA covers moving an existing clone to a different
+// pinned SHA, the path a Kargo promotion to a commit ref exercises.
+func TestNativeFetchCommitSHA(t *testing.T) {
+	t.Setenv("GIT_SSH_KEY_FILE", "")
+	t.Setenv("GIT_TOKEN_FILE", "")
+
+	repoPath, firstSHA, secondSHA := initFixtureRepo(t)
+	dst := filepath.Join(t.TempDir(), "clone")
+	client := &NativeGitClient{}
+	ctx := context.Background()
+
+	if _, err := client.CloneOrFetch(ctx, repoPath, "main", dst, nil); err != nil {
+		t.Fatalf("initial clone: %v", err)
+	}
+
+	result, err := client.CloneOrFetch(ctx, repoPath, firstSHA, dst, nil)
+	if err != nil {
+		t.Fatalf("fetch to first SHA: %v", err)
+	}
+	if result.Commit != firstSHA {
+		t.Errorf("commit after pin = %s, want %s", result.Commit, firstSHA)
+	}
+
+	result, err = client.CloneOrFetch(ctx, repoPath, secondSHA, dst, nil)
+	if err != nil {
+		t.Fatalf("fetch to second SHA: %v", err)
+	}
+	if result.Commit != secondSHA {
+		t.Errorf("commit after re-pin = %s, want %s", result.Commit, secondSHA)
+	}
+}
+
+// TestNativeCloneBranch pins the pre-existing branch clone path so the SHA
+// special-case doesn't regress it.
+func TestNativeCloneBranch(t *testing.T) {
+	t.Setenv("GIT_SSH_KEY_FILE", "")
+	t.Setenv("GIT_TOKEN_FILE", "")
+
+	repoPath, _, secondSHA := initFixtureRepo(t)
+	dst := filepath.Join(t.TempDir(), "clone")
+
+	client := &NativeGitClient{}
+	result, err := client.CloneOrFetch(context.Background(), repoPath, "main", dst, nil)
+	if err != nil {
+		t.Fatalf("CloneOrFetch with branch ref: %v", err)
+	}
+	if result.Commit != secondSHA {
+		t.Errorf("checked-out commit = %s, want branch head %s", result.Commit, secondSHA)
+	}
+}

--- a/internal/git/native_client_test.go
+++ b/internal/git/native_client_test.go
@@ -132,3 +132,41 @@ func TestNativeCloneBranch(t *testing.T) {
 		t.Errorf("checked-out commit = %s, want branch head %s", result.Commit, secondSHA)
 	}
 }
+
+// TestAuthURLStaysOutOfGitConfig guards the credential-handling contract:
+// the token-bearing URL form is only ever passed on the git command line,
+// while .git/config persists the credential-free URL. A persisted auth URL
+// would keep the token on disk for the lifetime of the repo volume. The
+// fixture path stands in for the auth URL; the clean URL is a sentinel that
+// is never contacted, so finding it (and only it) in config proves the
+// set-url/fetch split.
+func TestAuthURLStaysOutOfGitConfig(t *testing.T) {
+	repoPath, firstSHA, _ := initFixtureRepo(t)
+	const cleanURL = "https://example.invalid/repo.git"
+	dst := filepath.Join(t.TempDir(), "clone")
+	ctx := context.Background()
+
+	if _, err := nativeCloneAndCheckout(ctx, cleanURL, repoPath, "main", dst, nil); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	assertOriginURL(t, dst, cleanURL, repoPath)
+
+	if _, err := nativeFetchAndCheckout(ctx, cleanURL, repoPath, firstSHA, dst, nil); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	assertOriginURL(t, dst, cleanURL, repoPath)
+}
+
+func assertOriginURL(t *testing.T, repoDir, want, authURL string) {
+	t.Helper()
+	cfg, err := os.ReadFile(filepath.Join(repoDir, ".git", "config"))
+	if err != nil {
+		t.Fatalf("reading .git/config: %v", err)
+	}
+	if !strings.Contains(string(cfg), want) {
+		t.Errorf("origin URL not set to clean URL %q:\n%s", want, cfg)
+	}
+	if strings.Contains(string(cfg), authURL) {
+		t.Errorf("auth URL %q persisted in .git/config:\n%s", authURL, cfg)
+	}
+}


### PR DESCRIPTION
### 📖 Background

The CRD documents `spec.git.ref` as tag, branch, or commit SHA, but the agent's initial clone used `git clone --branch`, which rejects SHAs — a SHA-pinned CR failed permanently on a fresh pod. Separately, every fetch ran `remote set-url` with the token-injected URL, persisting the credential into `.git/config` on the repo volume for the lifetime of the pod.

### ⚙️ Changes

- SHA refs take an init + fetch + `checkout FETCH_HEAD` path on initial clone (GitHub/GitLab support fetching reachable SHAs directly); branch/tag clones are unchanged.
- `.git/config` now only ever holds the credential-free URL; the auth URL is passed to clone/fetch on the command line. A rotated token also takes effect on the next fetch instead of being pinned in config.
- `runGit` surfaces the exec error when git produces no output (previously an empty error message).

### 📝 Reviewer Notes

`nativeFetchAndCheckout` now takes both URL forms; the persisted remote is bookkeeping only — every fetch passes the URL explicitly.

### ☑️ Testing Notes

New tests use a local fixture repo with `allowReachableSHA1InWant` to mirror GitHub semantics: SHA clone, SHA re-pin on an existing clone, branch-clone regression, and an assertion that the auth URL form never lands in `.git/config`. Full Chainsaw e2e passed 41/41 on this branch's images.