### PR TITLE
fix: webhook receiver auth hardening and replica coverage

### DIFF
--- a/internal/webhook/inject.go
+++ b/internal/webhook/inject.go
@@ -186,14 +186,16 @@ func injectSidecar(pod *corev1.Pod, gs *stokerv1alpha1.GatewaySync) {
 		crName = gs.Name
 	}
 
-	// Gateway port and TLS from CR
+	// Gateway port and TLS from CR. The API server applies the CRD defaults
+	// (8088, TLS off); these fallbacks only fire when defaulting was bypassed
+	// and must agree with the CRD so behavior doesn't depend on the path taken.
 	gatewayPort := fmt.Sprintf("%d", gs.Spec.Gateway.Port)
 	if gs.Spec.Gateway.Port == 0 {
-		gatewayPort = "8043"
+		gatewayPort = "8088"
 	}
-	gatewayTLS := annotationTrue
-	if gs.Spec.Gateway.TLS != nil && !*gs.Spec.Gateway.TLS {
-		gatewayTLS = "false"
+	gatewayTLS := "false"
+	if gs.Spec.Gateway.TLS != nil && *gs.Spec.Gateway.TLS {
+		gatewayTLS = annotationTrue
 	}
 
 	// Build env vars

--- a/internal/webhook/receiver.go
+++ b/internal/webhook/receiver.go
@@ -2,6 +2,8 @@ package webhook
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,6 +36,13 @@ type Receiver struct {
 	BearerToken string
 	Port        int32
 	Recorder    record.EventRecorder
+}
+
+// NeedLeaderElection makes the receiver run on every replica, not just the
+// leader. The receiver Service load-balances across all pods; if only the
+// leader listened, webhooks routed to followers would be refused.
+func (rv *Receiver) NeedLeaderElection() bool {
+	return false
 }
 
 // Start starts the webhook HTTP server. Blocks until ctx is cancelled.
@@ -157,7 +166,11 @@ func (rv *Receiver) authorize(r *http.Request, body []byte) bool {
 		}
 	}
 	if rv.BearerToken != "" {
-		if r.Header.Get("Authorization") == "Bearer "+rv.BearerToken {
+		// Compare SHA-256 digests in constant time: hashing first equalizes
+		// length so neither content nor token length leaks via timing.
+		got := sha256.Sum256([]byte(r.Header.Get("Authorization")))
+		want := sha256.Sum256([]byte("Bearer " + rv.BearerToken))
+		if subtle.ConstantTimeCompare(got[:], want[:]) == 1 {
 			return true
 		}
 	}


### PR DESCRIPTION
### 📖 Background

Two receiver issues and one injector inconsistency from the security pass: bearer tokens were compared with `==` (timing oracle); with leader election and multiple replicas, only the leader listened on 9444 while the Service routed to every pod, so a share of webhooks got connection refused; and the injector's in-code port/TLS fallbacks (8043, TLS on) disagreed with the CRD defaults (8088, TLS off).

### ⚙️ Changes

- Bearer comparison hashes both sides with SHA-256 and compares with `subtle.ConstantTimeCompare` (hashing equalizes length so token length doesn't leak either).
- `Receiver` implements `NeedLeaderElection() = false` so every replica serves webhooks; annotating the CR is idempotent.
- Injector fallbacks now match the CRD defaults, so behavior doesn't depend on whether API-server defaulting ran.

### 📝 Reviewer Notes

Existing receiver tests (accept/reject/HMAC-fallback for bearer) exercise the constant-time rewrite; the `gateway-port-tls-defaults` e2e pins the 8088/false contract.

### ☑️ Testing Notes

`make build`, `make lint`, webhook unit tests green; receiver behavior covered by the webhook-receiver e2e suite.