### PR TITLE
fix: observability accuracy and credential freshness

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -45,9 +45,6 @@ func main() {
 
 	// Build event recorder (non-fatal if it fails).
 	recorder, shutdownRecorder := buildEventRecorder(log)
-	if shutdownRecorder != nil {
-		defer shutdownRecorder()
-	}
 
 	// Create and run the agent.
 	a := agent.New(cfg, k8sClient, recorder)
@@ -55,7 +52,14 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	if err := a.Run(logf.IntoContext(ctx, log)); err != nil {
+	err = a.Run(logf.IntoContext(ctx, log))
+
+	// Flush queued events before exiting — os.Exit skips defers, and the
+	// error path is exactly when the failure event must reach the API server.
+	if shutdownRecorder != nil {
+		shutdownRecorder()
+	}
+	if err != nil {
 		log.Error(err, "agent exited with error")
 		os.Exit(1)
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -74,8 +74,9 @@ func New(cfg *Config, k8sClient client.Client, recorder record.EventRecorder) *A
 	// Build exclude patterns.
 	excludes := []string{"**/.git/**", "**/.git", "**/.gitkeep", "**/.resources/**", "**/.resources"}
 
-	// Build Ignition API client.
-	igClient := ignition.NewClient(cfg.GatewayScheme(), cfg.GatewayHost(), cfg.APIKey())
+	// Build Ignition API client. The key is read per request so a rotated
+	// Secret takes effect without restarting the agent.
+	igClient := ignition.NewClient(cfg.GatewayScheme(), cfg.GatewayHost(), cfg.APIKey)
 
 	return &Agent{
 		Config:       cfg,

--- a/internal/controller/gateway_discovery.go
+++ b/internal/controller/gateway_discovery.go
@@ -51,6 +51,13 @@ func (r *GatewaySyncReconciler) discoverGateways(ctx context.Context, gs *stoker
 
 	discovered := make([]stokerv1alpha1.DiscoveredGateway, 0, len(podList.Items))
 
+	// Previous status by pod name, to emit MissingSidecar only on transition
+	// instead of on every reconcile (polling reconciles every 60s by default).
+	prevStatus := make(map[string]string, len(gs.Status.DiscoveredGateways))
+	for _, gw := range gs.Status.DiscoveredGateways {
+		prevStatus[gw.PodName] = gw.SyncStatus
+	}
+
 	for _, pod := range podList.Items {
 		// Filter by annotation
 		crName, ok := pod.Annotations[stokertypes.AnnotationCRName]
@@ -78,8 +85,10 @@ func (r *GatewaySyncReconciler) discoverGateways(ctx context.Context, gs *stoker
 		syncStatus := stokertypes.SyncStatusPending
 		if pod.Annotations[stokertypes.AnnotationInject] == "true" && !hasSyncAgent(&pod) {
 			syncStatus = stokertypes.SyncStatusMissingSidecar
-			r.Recorder.Eventf(gs, corev1.EventTypeWarning, "MissingSidecar",
-				"Pod %s has inject annotation but no stoker-agent sidecar — webhook may have been unavailable during pod creation. Delete and recreate the pod.", pod.Name)
+			if prevStatus[pod.Name] != stokertypes.SyncStatusMissingSidecar {
+				r.Recorder.Eventf(gs, corev1.EventTypeWarning, "MissingSidecar",
+					"Pod %s has inject annotation but no stoker-agent sidecar — webhook may have been unavailable during pod creation. Delete and recreate the pod.", pod.Name)
+			}
 		}
 
 		// Capture ServiceAccount for auto-RBAC binding.

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -179,6 +179,11 @@ func observeGatewayMetrics(gs *stokerv1alpha1.GatewaySync) {
 
 	gatewaysDiscovered.WithLabelValues(name, ns).Set(float64(len(gs.Status.DiscoveredGateways)))
 
+	// Clear per-gateway series before re-setting so gateways that disappeared
+	// (pod deleted, scaled down) don't keep reporting their last value forever.
+	gatewaySyncStatus.DeletePartialMatch(prometheus.Labels{labelName: name, labelNamespace: ns})
+	gatewayLastSyncTS.DeletePartialMatch(prometheus.Labels{labelName: name, labelNamespace: ns})
+
 	syncedCount := 0
 	missingSidecarCount := 0
 	for _, gw := range gs.Status.DiscoveredGateways {

--- a/internal/ignition/client.go
+++ b/internal/ignition/client.go
@@ -11,20 +11,27 @@ import (
 
 // Client wraps Ignition gateway API calls.
 type Client struct {
-	BaseURL    string
-	APIKey     string
+	BaseURL string
+	// APIKey returns the current API key. Resolved per request so a rotated
+	// Secret (kubelet refreshes the mounted file) takes effect without an
+	// agent restart. May be nil when no key is configured.
+	APIKey     func() string
 	HTTPClient *http.Client
 }
 
 // NewClient creates an Ignition API client.
 // scheme should be "http" or "https", host is the gateway address (e.g., "localhost:8088").
-func NewClient(scheme, host, apiKey string) *Client {
+// apiKey is invoked on every request; pass nil for unauthenticated access.
+func NewClient(scheme, host string, apiKey func() string) *Client {
 	return &Client{
 		BaseURL: fmt.Sprintf("%s://%s", scheme, host),
 		APIKey:  apiKey,
 		HTTPClient: &http.Client{
 			Timeout: 10 * time.Second,
 			Transport: &http.Transport{
+				// The gateway is reached over the pod's loopback interface; its
+				// certificate is typically self-signed and never matches
+				// "localhost", so verification is skipped for this same-pod hop.
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
 		},
@@ -148,7 +155,10 @@ func (c *Client) PortCheck() error {
 
 // setAuth adds the Ignition API key header to a request.
 func (c *Client) setAuth(req *http.Request) {
-	if c.APIKey != "" {
-		req.Header.Set("X-Ignition-API-Token", strings.TrimSpace(c.APIKey))
+	if c.APIKey == nil {
+		return
+	}
+	if key := strings.TrimSpace(c.APIKey()); key != "" {
+		req.Header.Set("X-Ignition-API-Token", key)
 	}
 }


### PR DESCRIPTION
### 📖 Background

Three smaller issues from the observability pass: the MissingSidecar warning event fired on every reconcile (every 60s with default polling) for as long as an affected pod existed; per-gateway metric series outlived their gateways, reporting the last value forever after a pod was deleted or scaled down; and the Ignition API key was read from the mounted Secret once at agent startup, so rotating it broke scan and designer-session calls until every gateway pod restarted.

### ⚙️ Changes

- Emit MissingSidecar only when a pod transitions into that state.
- Clear the CR's per-gateway metric series before re-observing, so departed gateways drop out of `stoker_controller_gateway_sync_status` and `..._last_sync_timestamp_seconds`.
- `ignition.Client` resolves the API key per request via a function (kubelet refreshes the mounted Secret file); also documents why TLS verification is skipped on the same-pod loopback hop.
- `cmd/agent` flushes the event recorder before `os.Exit(1)` — the queued failure event was dropped exactly when it mattered.

### 📝 Reviewer Notes

`NewClient` now takes `func() string` instead of a string; the only caller passes `cfg.APIKey` (a method value that reads the file).

### ☑️ Testing Notes

`make build`, `make lint`, full unit suite green on this branch rebased onto current main.