### PR TITLE
chore: chart hygiene - priorityClassName, port naming, RBAC name note

### DIFF
--- a/charts/stoker-operator/README.md
+++ b/charts/stoker-operator/README.md
@@ -117,6 +117,7 @@ Kubernetes: `>= 1.28.0`
 | podMonitor.interval | string | `""` | Scrape interval. Falls back to the Prometheus default if empty. |
 | podMonitor.labels | object | `{}` | Additional labels for the PodMonitor (e.g. for Prometheus selector matching). |
 | podMonitor.scrapeTimeout | string | `""` | Scrape timeout. Falls back to the Prometheus default if empty. |
+| priorityClassName | string | `""` | PriorityClass for the controller pod, e.g. system-cluster-critical. Protects the operator from eviction under node pressure. |
 | prometheusRule | object | `{"additionalRules":[],"enabled":false,"labels":{}}` | PrometheusRule for Stoker alerting rules. Requires the prometheus-operator CRDs to be installed in the cluster. |
 | prometheusRule.additionalRules | list | `[]` | Additional alerting rules appended to the default set. |
 | prometheusRule.enabled | bool | `false` | Create a PrometheusRule resource with default alerts. |

--- a/charts/stoker-operator/templates/agent-clusterrole.yaml
+++ b/charts/stoker-operator/templates/agent-clusterrole.yaml
@@ -1,6 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  # The name is load-bearing: the controller's auto-RBAC binds RoleBindings to
+  # the ClusterRole named "stoker-agent" (agentClusterRoleName in
+  # internal/controller/rbac.go). Renaming it here silently breaks auto-RBAC.
   name: stoker-agent
   labels:
     {{- include "stoker-operator.labels" . | nindent 4 }}

--- a/charts/stoker-operator/templates/deployment.yaml
+++ b/charts/stoker-operator/templates/deployment.yaml
@@ -134,6 +134,9 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "stoker-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/stoker-operator/templates/webhook-receiver-service.yaml
+++ b/charts/stoker-operator/templates/webhook-receiver-service.yaml
@@ -12,7 +12,7 @@ spec:
     - port: {{ .Values.webhookReceiver.port | default 9444 }}
       targetPort: webhook-rx
       protocol: TCP
-      name: http
+      name: webhook-rx
   selector:
     {{- include "stoker-operator.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/stoker-operator/values.yaml
+++ b/charts/stoker-operator/values.yaml
@@ -239,3 +239,8 @@ tolerations: []
 
 # -- Affinity rules for scheduling the controller pod.
 affinity: {}
+
+# -- PriorityClass for the controller pod, e.g. system-cluster-critical.
+# Protects the operator from eviction under node pressure.
+priorityClassName: ""
+


### PR DESCRIPTION
### 📖 Background

Small chart-audit findings. The operator pod couldn't be given a PriorityClass, so under node pressure it was evicted like any workload despite gating gateway config delivery. The webhook-receiver Service named its port `http` while the container port is `webhook-rx`. And the `stoker-agent` ClusterRole name silently breaks the controller's auto-RBAC if renamed, with nothing in the template saying so.

### ⚙️ Changes

- `priorityClassName` values passthrough on the controller Deployment (default empty, helm-docs regenerated).
- Receiver Service port renamed to `webhook-rx` to match the container port; the ingress references the port by number, so the rename is inert.
- Comment in `agent-clusterrole.yaml` documenting the coupling with `agentClusterRoleName` in `internal/controller/rbac.go`.

### 📝 Reviewer Notes

Chart version intentionally untouched: the release workflow rewrites `version`/`appVersion` at publish time.

### ☑️ Testing Notes

`helm lint` and `helm template` verified, including `priorityClassName` set and receiver enabled.