### PR TITLE
test: cover ignition client and designer session policies

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/ia-eknorr/stoker-operator/internal/ignition"
+	stokertypes "github.com/ia-eknorr/stoker-operator/pkg/types"
+)
+
+// newTestAgent wires an Agent against a fake K8s client and a stub gateway
+// that reports the given designer sessions JSON.
+func newTestAgent(t *testing.T, designersJSON string) (*Agent, client.Client) {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	k8s := fake.NewClientBuilder().WithScheme(s).Build()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/data/api/v1/designers" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(designersJSON))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &Config{
+		CRName:      "test-cr",
+		CRNamespace: "test-ns",
+		GatewayName: "gw-0",
+		PodName:     "gw-0",
+	}
+	a := &Agent{
+		Config:      cfg,
+		K8sClient:   k8s,
+		IgnitionAPI: ignition.NewClient("http", strings.TrimPrefix(srv.URL, "http://"), nil),
+		Metrics:     NewAgentMetrics(),
+	}
+	return a, k8s
+}
+
+// TestCheckDesignerSessionsPolicies pins the policy matrix that decides
+// whether a sync proceeds while users have Designer sessions open. A wrong
+// answer either clobbers in-flight design work (should-block treated as
+// proceed) or wedges deployments (should-proceed treated as block).
+func TestCheckDesignerSessionsPolicies(t *testing.T) {
+	oneSession := `{"items":[{"id":"1","user":"alice","project":"demo"}]}`
+	cases := []struct {
+		name      string
+		policy    string
+		designers string
+		wantBlock bool
+	}{
+		{"proceed with active sessions", "proceed", oneSession, false},
+		{"fail with active sessions", "fail", oneSession, true},
+		{"empty policy defaults to proceed", "", oneSession, false},
+		{"unknown policy proceeds", "yolo", oneSession, false},
+		{"fail with no sessions", "fail", `{"items":[]}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, _ := newTestAgent(t, tc.designers)
+			blocked := a.checkDesignerSessions(context.Background(), tc.policy, "abc123", "main")
+			if blocked != tc.wantBlock {
+				t.Errorf("blocked = %v, want %v", blocked, tc.wantBlock)
+			}
+		})
+	}
+}
+
+// TestCheckDesignerSessionsFailWritesErrorStatus ensures a policy=fail block
+// is surfaced to the controller via the status ConfigMap, not just logged —
+// that's the only signal an operator sees in kubectl.
+func TestCheckDesignerSessionsFailWritesErrorStatus(t *testing.T) {
+	a, k8s := newTestAgent(t, `{"items":[{"id":"1","user":"alice","project":"demo"}]}`)
+
+	if blocked := a.checkDesignerSessions(context.Background(), "fail", "abc123", "main"); !blocked {
+		t.Fatal("policy=fail with active sessions must block")
+	}
+
+	cm := &corev1.ConfigMap{}
+	key := client.ObjectKey{Name: StatusConfigMapName("test-cr"), Namespace: "test-ns"}
+	if err := k8s.Get(context.Background(), key, cm); err != nil {
+		t.Fatalf("status ConfigMap not written: %v", err)
+	}
+	status := cm.Data["gw-0"]
+	if !strings.Contains(status, stokertypes.SyncStatusError) || !strings.Contains(status, "alice") {
+		t.Errorf("status entry missing error/session info: %s", status)
+	}
+}
+
+// TestCheckDesignerSessionsAPIErrorProceeds pins the fail-open choice: if the
+// designer API is unreachable the sync continues, because blocking config
+// delivery on a flaky introspection endpoint is worse than a rare sync during
+// a session.
+func TestCheckDesignerSessionsAPIErrorProceeds(t *testing.T) {
+	a, _ := newTestAgent(t, "")
+	// Point the client at a closed port to force a connection error.
+	a.IgnitionAPI = ignition.NewClient("http", "127.0.0.1:1", nil)
+
+	if blocked := a.checkDesignerSessions(context.Background(), "fail", "abc123", "main"); blocked {
+		t.Error("designer API error must not block the sync")
+	}
+}

--- a/internal/ignition/client_test.go
+++ b/internal/ignition/client_test.go
@@ -1,0 +1,182 @@
+package ignition
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// scanRecorder captures requests to the fake gateway so tests can assert on
+// call order, paths, and auth headers.
+type scanRecorder struct {
+	mu       sync.Mutex
+	paths    []string
+	keys     []string
+	statuses map[string]int // per-path response status; 0 means 200
+}
+
+func (r *scanRecorder) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		r.mu.Lock()
+		r.paths = append(r.paths, req.URL.Path)
+		r.keys = append(r.keys, req.Header.Get("X-Ignition-API-Token"))
+		status := r.statuses[req.URL.Path]
+		r.mu.Unlock()
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+	}
+}
+
+func newTestClient(t *testing.T, rec *scanRecorder, key func() string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(rec.handler())
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	return NewClient("http", host, key)
+}
+
+// TestTriggerScanOrderAndAuth pins the scan contract Ignition requires:
+// projects are scanned before config, and every call carries the API key.
+// Out-of-order scans make the gateway load projects referencing config that
+// hasn't been re-read yet.
+func TestTriggerScanOrderAndAuth(t *testing.T) {
+	rec := &scanRecorder{statuses: map[string]int{}}
+	c := newTestClient(t, rec, func() string { return " test-key\n" })
+
+	result := c.TriggerScan()
+	if result.Error != "" {
+		t.Fatalf("TriggerScan error: %s", result.Error)
+	}
+	if result.ProjectsStatus != 200 || result.ConfigStatus != 200 {
+		t.Errorf("statuses = %d/%d, want 200/200", result.ProjectsStatus, result.ConfigStatus)
+	}
+
+	wantPaths := []string{"/data/api/v1/scan/projects", "/data/api/v1/scan/config"}
+	if len(rec.paths) != 2 || rec.paths[0] != wantPaths[0] || rec.paths[1] != wantPaths[1] {
+		t.Errorf("scan paths = %v, want %v (projects before config)", rec.paths, wantPaths)
+	}
+	for i, k := range rec.keys {
+		if k != "test-key" {
+			t.Errorf("request %d API key header = %q, want trimmed %q", i, k, "test-key")
+		}
+	}
+}
+
+// TestTriggerScanProjectsFailureSkipsConfig ensures a failed projects scan
+// short-circuits: scanning config after a failed projects scan would apply
+// half the new state.
+func TestTriggerScanProjectsFailureSkipsConfig(t *testing.T) {
+	rec := &scanRecorder{statuses: map[string]int{
+		"/data/api/v1/scan/projects": http.StatusInternalServerError,
+	}}
+	c := newTestClient(t, rec, nil)
+
+	result := c.TriggerScan()
+	if result.Error == "" {
+		t.Fatal("expected error when projects scan fails")
+	}
+	for _, p := range rec.paths {
+		if p == "/data/api/v1/scan/config" {
+			t.Error("config scan must not run after projects scan failed")
+		}
+	}
+}
+
+// TestPortCheck pins the post-commission readiness semantics: any HTTP
+// response except 503 means the gateway is up, even an auth rejection,
+// because commissioning may have reset the API token's access.
+func TestPortCheck(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{"unauthorized still counts as up", http.StatusUnauthorized, false},
+		{"ok", http.StatusOK, false},
+		{"still starting", http.StatusServiceUnavailable, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &scanRecorder{statuses: map[string]int{"/system/gwinfo": tc.status}}
+			c := newTestClient(t, rec, nil)
+			err := c.PortCheck()
+			if tc.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestSetAuthNilKeyFunc guards the nil-func contract added when the key
+// became lazily resolved: a client built with no key must not panic and must
+// not send an empty auth header.
+func TestSetAuthNilKeyFunc(t *testing.T) {
+	rec := &scanRecorder{statuses: map[string]int{}}
+	c := newTestClient(t, rec, nil)
+
+	if err := c.HealthCheck(); err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if len(rec.keys) != 1 || rec.keys[0] != "" {
+		t.Errorf("auth header sent without a key func: %v", rec.keys)
+	}
+}
+
+// TestGetDesignerSessions covers the envelope decode and the empty-items
+// normalization the wait policy relies on (nil items would make len() checks
+// ambiguous against a decode failure).
+func TestGetDesignerSessions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"id":"1","user":"alice","project":"demo"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("http", strings.TrimPrefix(srv.URL, "http://"), nil)
+
+	sessions, err := c.GetDesignerSessions(context.Background())
+	if err != nil {
+		t.Fatalf("GetDesignerSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].User != "alice" || sessions[0].Project != "demo" {
+		t.Errorf("sessions = %+v, want one alice/demo session", sessions)
+	}
+}
+
+func TestGetDesignerSessionsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("http", strings.TrimPrefix(srv.URL, "http://"), nil)
+
+	sessions, err := c.GetDesignerSessions(context.Background())
+	if err != nil {
+		t.Fatalf("GetDesignerSessions: %v", err)
+	}
+	if sessions == nil {
+		t.Error("sessions must be non-nil empty slice when items are absent")
+	}
+	if len(sessions) != 0 {
+		t.Errorf("sessions = %+v, want empty", sessions)
+	}
+}
+
+func TestGetDesignerSessionsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("http", strings.TrimPrefix(srv.URL, "http://"), nil)
+
+	if _, err := c.GetDesignerSessions(context.Background()); err == nil {
+		t.Error("expected error on HTTP 403")
+	}
+}


### PR DESCRIPTION
### 📖 Background

`internal/ignition` had zero test coverage despite owning behavior the sync loop depends on: the scan ordering contract (projects before config — out-of-order scans load projects against stale config), the post-commission `PortCheck` semantics (any response but 503 means the gateway is up, even an auth rejection), and the designer-session envelope decode. The agent's designer policy matrix was similarly untested.

### ⚙️ Changes

Httptest-backed tests for the ignition client (scan order + auth header, short-circuit on projects failure, PortCheck matrix, nil key func contract, designer envelope/empty/error cases) and a fake-client agent harness covering the proceed/fail/unknown policy matrix, the fail-open choice when the designer API is unreachable, and the requirement that a policy=fail block lands in the status ConfigMap.

### 📝 Reviewer Notes

Every test opens with a comment justifying what contract it pins. The projects-failure test takes ~6s because it rides the client's real retry backoff.

### ☑️ Testing Notes

Tests-only change; `make lint` and the full unit suite pass.