### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.6.1] - 2026-06-12
+
+A correctness, security, and observability hardening release. No new features, CRD changes, or breaking changes; safe to upgrade in place from v0.6.0.
+
+### Security
+
+- **Constant-time webhook token comparison**: the webhook receiver's bearer-token check now runs in constant time, closing a timing oracle that could leak the configured token byte by byte (#155).
+- **Git token no longer persisted to disk**: the native git client stops writing the credential-bearing URL into `.git/config`. Fetches use the auth URL directly and the persisted `origin` remote is rewritten to its credential-free form (#154).
+- **GitHub App token exchange is bounded by a timeout**: the controller's HTTP call to exchange the App PEM for an installation token previously ran under a deadline-free context and could hang indefinitely; it now has an explicit timeout (#150).
+
+### Fixed
+
+- **Controller data race under concurrent reconciles**: with `MaxConcurrentReconciles: 5`, two GatewaySync CRs reconciling at once could trigger a concurrent map-write panic on the reconciler's shared token-cache and backoff maps. Access is now synchronized (#150).
+- **RBAC no longer revoked on transient pod-List failures**: a failed pod List could silently rewrite an agent RoleBinding's subjects to `default`, stripping permissions from live agents. The reconciler now treats the List error as retryable instead of acting on an empty result (#150).
+- **Pods without a profile annotation use the documented default**: pods missing the `stoker.io/profile` annotation crash-looped despite the CRD documenting a `default-profile` fallback; the fallback now applies as specified (#152).
+- **Concurrent syncs no longer corrupt the staging directory**: the post-commission goroutine and the watcher loop could run overlapping syncs sharing one staging directory and mutually `RemoveAll` each other's files. Syncs are now serialized (#152).
+- **Atomic live-file writes**: files are written via temp-file-and-rename instead of truncate-in-place, so a killed agent can no longer leave half-written SCADA config for the gateway to scan (#152).
+- **Commit-SHA refs clone correctly**: a commit-SHA ref produced an invalid `git clone --branch <sha>` that broke the initial clone permanently; SHA refs now use init, fetch, then checkout (#154).
+- **Failed post-sync scan retries**: a failed post-sync scan left the gateway in `Error` with no retry until the next commit. The agent now returns an error so the existing backoff retries it (#158).
+- **Webhook receiver runs on every replica**: the receiver previously ran only on the leader, so a share of webhooks reached replicas that returned connection-refused behind the Service. It now serves on all replicas, and injector port/TLS fallbacks are aligned with the CRD defaults (#155).
+
+### Changed
+
+- **`MissingSidecar` event fires only on transition**: it was re-emitted every 60s indefinitely; it now fires only when a gateway enters the missing-sidecar state (#156).
+- **Per-gateway metrics are cleaned up on pod deletion**: metric series for a gateway are removed when its pod is deleted instead of outliving it forever (#156).
+- **Ignition API key is read per request**: the agent re-reads the key from its mount on each request, so Secret rotation takes effect without a pod restart (#156).
+- The agent now flushes its event recorder before exiting on error (#156).
+- Removed a dead go-git auth code path that implied a token-delivery channel which does not exist (#152).
+
+### Documentation
+
+- Corrected `CLAUDE.md` and the architecture docs: GitHub App tokens are delivered via Secret, not ConfigMap, and references to the vestigial `stoker-changes` ConfigMap and the never-implemented ref-override annotation constant were removed (#151).
+
+### Tests
+
+- Added coverage for the previously-untested Ignition client (scan ordering, `PortCheck` semantics) and the designer-session policy matrix. Coverage: ignition 0 to 81%, agent 20 to 46%, git 30 to 42% (#160).
+
+### Infrastructure
+
+- **Chart hygiene**: `priorityClassName` passthrough, consistent port naming, and a load-bearing-name comment on the agent ClusterRole (#159).
+- `make e2e` now falls back to loading images from an archive when `kind load docker-image` fails against Docker's containerd image store (#153).
+
 ## [v0.6.0] - 2026-05-24
 
 ### Security
@@ -210,6 +252,10 @@ Initial release — controller + agent sidecar for Git-driven Ignition gateway c
 - **Functional test suite** with phased kind cluster tests (phases 02-09)
 - Unit tests with envtest for controller and syncengine
 
+[v0.6.1]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.6.1
+[v0.6.0]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.6.0
+[v0.5.3]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.5.3
+[v0.5.2]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.5.2
 [v0.5.1]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.5.1
 [v0.5.0]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.5.0
 [v0.4.10]: https://github.com/ia-eknorr/stoker-operator/releases/tag/v0.4.10

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -6,7 +6,7 @@ description: Planned features and milestones for Stoker.
 
 # Roadmap
 
-Current version: **v0.5.2** — [see the changelog](https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md) for release history.
+Current version: **v0.6.1**. [See the changelog](https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md) for release history.
 
 ## v0.6.0 — Scale & Operability
 

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -17,7 +17,10 @@ import (
 	transportclient "github.com/go-git/go-git/v5/plumbing/transport/client"
 )
 
-const gitRemoteOrigin = "origin"
+const (
+	gitRemoteOrigin = "origin"
+	gitSubcmdRemote = "remote"
+)
 
 // Result holds the outcome of a clone or fetch operation.
 type Result struct {
@@ -359,7 +362,7 @@ func nativeCloneAndCheckout(ctx context.Context, cleanURL, authURL, ref, path st
 		if _, err := runGit(ctx, []string{"init", path}, "", env); err != nil {
 			return Result{}, fmt.Errorf("git init: %w", err)
 		}
-		if _, err := runGit(ctx, []string{"remote", "add", gitRemoteOrigin, cleanURL}, path, env); err != nil {
+		if _, err := runGit(ctx, []string{gitSubcmdRemote, "add", gitRemoteOrigin, cleanURL}, path, env); err != nil {
 			return Result{}, fmt.Errorf("git remote add: %w", err)
 		}
 		return nativeFetchAndCheckout(ctx, cleanURL, authURL, ref, path, env)
@@ -369,7 +372,7 @@ func nativeCloneAndCheckout(ctx context.Context, cleanURL, authURL, ref, path st
 		return Result{}, fmt.Errorf("git clone --branch %s: %w", ref, err)
 	}
 	// Replace the persisted origin URL with the credential-free form.
-	if _, err := runGit(ctx, []string{"remote", "set-url", gitRemoteOrigin, cleanURL}, path, env); err != nil {
+	if _, err := runGit(ctx, []string{gitSubcmdRemote, "set-url", gitRemoteOrigin, cleanURL}, path, env); err != nil {
 		return Result{}, fmt.Errorf("git remote set-url: %w", err)
 	}
 	return nativeRevParse(ctx, ref, path, env)
@@ -378,7 +381,7 @@ func nativeCloneAndCheckout(ctx context.Context, cleanURL, authURL, ref, path st
 func nativeFetchAndCheckout(ctx context.Context, cleanURL, authURL, ref, path string, env []string) (Result, error) {
 	// Keep the persisted remote URL current with the CR spec (credential-free);
 	// the fetch itself uses the auth URL directly so the token stays off disk.
-	if _, err := runGit(ctx, []string{"remote", "set-url", gitRemoteOrigin, cleanURL}, path, env); err != nil {
+	if _, err := runGit(ctx, []string{gitSubcmdRemote, "set-url", gitRemoteOrigin, cleanURL}, path, env); err != nil {
 		return Result{}, fmt.Errorf("git remote set-url: %w", err)
 	}
 	if _, err := runGit(ctx, []string{"fetch", "--depth=1", authURL, ref}, path, env); err != nil {


### PR DESCRIPTION
### 📖 Background

v0.6.1 cuts a release for the correctness, security, and observability hardening work merged since v0.6.0 (PRs #150, #152, #154, #155, #156, #158 plus supporting tests, docs, chart, and infra changes). It is a pure fix release: no new features, no CRD changes, no breaking changes, safe to upgrade in place from v0.6.0.

It also unblocks the release itself. The `goconst` lint on `internal/git/client.go` has been red on `main` since the native git client landed, and because the release workflow fires on the tag, tagging against a red `main` would ship from a failing tree.

### ⚙️ Changes

- **Lint fix (unblocks release):** extract the repeated `"remote"` git subcommand into a `gitSubcmdRemote` constant so `golangci-lint` passes. No behavior change.
- **Changelog:** add the `## [v0.6.1] - 2026-06-12` entry mapping every merged PR to Keep a Changelog categories (Security / Fixed / Changed / Documentation / Tests / Infrastructure), and backfill the dangling `[v0.6.0]`/`[v0.5.3]`/`[v0.5.2]` reference links.
- **Docs:** bump the `Current version` line in the roadmap from the stale `v0.5.2` to `v0.6.1`.

### 📝 Reviewer Notes

This PR carries no product code change beyond the constant extraction; the substance of the release already merged across the linked PRs. The version itself is a patch bump on purpose: everything in the window is a fix or hardening, so `v0.7.0` stays reserved for the planned "Conditions & Validation" milestone in the roadmap.

After merge, tagging `v0.6.1` on the squashed/merged commit triggers the image, chart, and GitHub release build.

### ☑️ Testing Notes

- `golangci-lint run ./...` → `0 issues`, `go build ./...` clean, and the `internal/git` unit suite passes locally with the constant extraction.
- E2E is covered by CI: the suite already passed on the current `main` HEAD in an isolated cluster, and it runs again on this PR. No further behavior is introduced here to verify.