### PR TITLE
docs: rewrite roadmap in priority order

### DIFF
--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -6,47 +6,57 @@ description: Planned features and milestones for Stoker.
 
 # Roadmap
 
-Current version: **v0.5.2** — [see the changelog](https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md) for release history.
+Current version: **v0.6.1**. [See the changelog](https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md) for release history.
 
-## v0.6.0 — Scale & Operability
+Items are ordered by priority: the first section is what gets built next. Later sections move up based on user feedback and evidence of need.
 
-Remove scaling walls and make the agent more reactive.
+## Next: validation and visibility
 
-- Informer-based ConfigMap watch replacing 3s polling in agent
-- Downward API annotation reader — enables `stoker.io/ref-override` and profile switching without pod restart
-- Per-gateway status ConfigMap sharding (eliminate write contention at 10+ gateways)
-- `emptyDir` size limit on agent repo volume (prevent node disk pressure from large repos)
+Make invalid configuration impossible to apply, and make sync behavior observable without reading agent logs.
+
+- CEL validation rules on the GatewaySync CRD: reject invalid CRs at apply time with no webhook round trip; an admission webhook follows only for checks CEL cannot express
+- Conflict detection when multiple profiles map to the same destination path
+- New condition types: `AgentReady`, `RefSkew`
+- Structured audit logging: per-sync JSON record with timestamp, commit, author, gateway, files, and result
+- Sync diff report included in the audit record
+- Post-sync health verification: confirm project state and tag providers, not just a scan 200
+- Drift detection: re-syncing the same commit reports unexpected changes
+- `emptyDir` size limit on the agent repo volume (prevents node disk pressure from large repos)
 - Webhook receiver rate limiting
 
-## v0.7.0 — Conditions & Validation
+## Later: scale
 
-Operational visibility and safety for fleet management.
+Remove scaling walls once fleet sizes demand it. A scale test (10+ gateways on a single CR) gates this work and measures whether the contention is real before anything gets built.
 
-- New condition types: `AgentReady`, `RefSkew`
-- Drift detection (re-sync same commit reports unexpected changes)
-- Post-sync health verification (project state, tag providers — not just scan 200)
-- Sync diff report in changes ConfigMap
-- Conflict detection when multiple profiles map to the same destination path
-- Validating admission webhook for GatewaySync CRs (reject invalid CRs at apply time)
-- Structured audit logging (per-sync JSON record: timestamp, commit, author, gateway, files, result)
+- Informer-based metadata ConfigMap watch replacing the agent's 3s polling
+- Per-gateway status ConfigMap sharding to eliminate write contention at 10+ gateways
 
-## Future Ideas
+## Later: API graduation
 
-These are valuable but not yet scoped into versioned milestones. They'll be prioritized based on user feedback.
+Stabilize the API before wider adoption makes breaking changes expensive.
 
-**Safety & Trust:**
-- Designer session project-level granularity (sync Project B while designer has Project A open)
-- Pre-sync backup with auto-rollback on scan failure
+- Graduate `stoker.io/v1alpha1` to `v1beta1` with a conversion path and a field deprecation policy
+
+## Future ideas
+
+These are valuable but not yet scoped into milestones. They'll be prioritized based on user feedback.
+
+**Safety and trust:**
+
+- Designer session project-level granularity (sync Project B while a designer has Project A open)
+- Pre-sync backup with automatic rollback on scan failure
 - Module management (`.modl` sync to `modules/` with `postAction: restart`)
-- Per-CR webhook HMAC secrets (replace global HMAC)
-- Git commit signature verification (GPG/SSH, IEC 62443 compliance)
+- Per-CR webhook HMAC secrets replacing the global secret
+- Git commit signature verification (GPG/SSH) for IEC 62443 compliance
 
 **Reach:**
-- Standalone agent mode (systemd/Windows service for bare-metal Ignition servers)
+
+- Standalone agent mode (systemd or Windows service for bare-metal Ignition servers)
 - Approval annotation gate for production gateways
 
 **Enterprise:**
+
+- Configurable drift action (report, restore, or alert) building on drift detection
 - Maintenance windows and change freeze schedules
-- External audit sink (SIEM integration via webhook/syslog)
-- Drift detection with configurable action (report / restore / alert)
+- External audit sink (SIEM integration via webhook or syslog)
 - Resource quotas and rate limiting for concurrent syncs

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -8,38 +8,49 @@ description: Planned features and milestones for Stoker.
 
 Current version: **v0.6.1**. [See the changelog](https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md) for release history.
 
-Items are ordered by priority: the first section is what gets built next. Later sections move up based on user feedback and evidence of need.
+Milestones are release targets in priority order, not promises: scope can shift between minors, and the changelog records what actually shipped.
 
-## Next: validation and visibility
+## v0.7.0 - Validation and conditions
 
-Make invalid configuration impossible to apply, and make sync behavior observable without reading agent logs.
+Reject invalid configuration at apply time, and surface agent state where `kubectl get gs` can see it.
 
-- CEL validation rules on the GatewaySync CRD: reject invalid CRs at apply time with no webhook round trip; an admission webhook follows only for checks CEL cannot express
-- Conflict detection when multiple profiles map to the same destination path
+- CEL validation rules on the GatewaySync CRD: reject invalid CRs at apply time with no webhook round trip
+- Conflict detection when multiple profiles map to the same destination path (admission webhook only if CEL cannot express the check)
 - New condition types: `AgentReady`, `RefSkew`
+- `emptyDir` size limit on the agent repo volume (prevents node disk pressure from large repos)
+- Webhook receiver rate limiting
+
+## v0.8.0 - Sync transparency
+
+Answer "what did the last sync actually do" without reading agent logs.
+
 - Structured audit logging: per-sync JSON record with timestamp, commit, author, gateway, files, and result
 - Sync diff report included in the audit record
 - Post-sync health verification: confirm project state and tag providers, not just a scan 200
 - Drift detection: re-syncing the same commit reports unexpected changes
-- `emptyDir` size limit on the agent repo volume (prevents node disk pressure from large repos)
-- Webhook receiver rate limiting
 
-## Later: scale
+## v0.9.0 - Scale
 
-Remove scaling walls once fleet sizes demand it. A scale test (10+ gateways on a single CR) gates this work and measures whether the contention is real before anything gets built.
+Remove scaling walls for larger fleets. The scale test lands first and measures the contention before any fix is built.
 
+- Scale e2e test: 10+ gateways on a single CR, asserting sync latency and ConfigMap write behavior
 - Informer-based metadata ConfigMap watch replacing the agent's 3s polling
-- Per-gateway status ConfigMap sharding to eliminate write contention at 10+ gateways
+- Per-gateway status ConfigMap sharding to eliminate write contention
 
-## Later: API graduation
+## v1.0.0 - Stable API
 
-Stabilize the API before wider adoption makes breaking changes expensive.
+v1.0.0 graduates the API from `stoker.io/v1alpha1` to `stoker.io/v1beta1`, with conversion between served versions and a deprecation window before `v1alpha1` is removed.
 
-- Graduate `stoker.io/v1alpha1` to `v1beta1` with a conversion path and a field deprecation policy
+It ships when these criteria hold:
+
+- v0.7.0 through v0.9.0 landed without breaking CRD schema changes, demonstrating the API shape is right
+- Invalid configuration is rejected at apply time, not discovered at sync time
+- Behavior at 10+ gateways per CR is measured by the scale test and documented
+- The upgrade path between minor versions is covered by e2e tests
 
 ## Future ideas
 
-These are valuable but not yet scoped into milestones. They'll be prioritized based on user feedback.
+These are valuable but not yet scoped into a release. They'll be prioritized into post-1.0 milestones based on user feedback.
 
 **Safety and trust:**
 


### PR DESCRIPTION
### 📖 Background
A roadmap audit against main found the doc fully stale: the header still said v0.5.2, the "v0.6.0 - Scale & Operability" milestone shipped none of its five items (v0.6.0 was two security fixes instead), and nothing in the v0.7.0 milestone or Future Ideas has been started. The rewrite makes the roadmap match reality and gives each milestone a concrete release target.

### ⚙️ Changes
- Re-sort all work into versioned release targets in priority order: v0.7.0 (validation and conditions), v0.8.0 (sync transparency), v0.9.0 (scale), v1.0.0 (stable API)
- Define explicit v1.0.0 readiness criteria and tie the release to graduating the API from v1alpha1 to v1beta1 with a conversion path and deprecation window
- Drop the downward API annotation reader: ref overrides already flow through the webhook receiver and profile changes already re-sync without a pod restart, so it would add a second source of truth for a solved problem
- Re-scope CR validation to CEL rules on the CRD first, with an admission webhook only for checks CEL cannot express (such as profile destination conflicts)
- Move the sync diff report into the structured audit record, since the changes ConfigMap it referenced no longer exists
- Dedupe drift detection, which appeared twice: report-only detection lands in v0.8.0, configurable action (report/restore/alert) stays an Enterprise follow-on
- Gate the v0.9.0 scale items (informer-based watch, status ConfigMap sharding) behind a scale e2e test that measures the contention before anything gets built
- Bump the header version to v0.6.1

### 📝 Reviewer Notes
The version line is word-for-word identical to the one in #161, so git resolves that hunk cleanly whichever PR merges first.

### ☑️ Testing Notes
Content-only Markdown change: frontmatter, sidebar position, and links are unchanged, and the changelog link target is the same as before.