### PR TITLE
docs: remove condescending phrasing from concepts and quickstart

### DIFF
--- a/docs/docs/overview/concepts.md
+++ b/docs/docs/overview/concepts.md
@@ -1,16 +1,14 @@
 ---
 sidebar_position: 3
 title: Concepts
-description: Key terms from Kubernetes and Ignition explained for both audiences.
+description: Key Kubernetes and Stoker terms used throughout the docs.
 ---
 
 # Concepts
 
-Stoker is a Kubernetes operator for Ignition SCADA gateways. This page explains key Kubernetes and Stoker-specific terms so you can follow the docs even if you're new to the platform.
+Stoker is a Kubernetes operator for Ignition SCADA gateways. This page defines key Kubernetes and Stoker-specific terms used throughout the docs.
 
 ## Kubernetes concepts
-
-If you're an Ignition integrator who hasn't worked with Kubernetes before, these are the terms you'll encounter throughout the docs.
 
 | Term | What it means |
 |------|--------------|
@@ -27,7 +25,7 @@ If you're an Ignition integrator who hasn't worked with Kubernetes before, these
 | **Helm** | A package manager for Kubernetes. Stoker is installed via a Helm chart that templates all the Kubernetes resources. |
 | **MutatingWebhook** | A Kubernetes feature that intercepts object creation and modifies it. Stoker's webhook automatically injects the agent sidecar into gateway pods — you don't configure the sidecar manually. |
 | **RBAC (Role-Based Access Control)** | Kubernetes permission system. The agent sidecar needs permissions to read ConfigMaps in its namespace. |
-| **kubectl** | The command-line tool for interacting with a Kubernetes cluster. Equivalent to using the Ignition Gateway Webpage, but via terminal commands. |
+| **kubectl** | The command-line tool for interacting with a Kubernetes cluster. Used throughout this guide to apply resources, inspect status, and view logs. |
 
 ## Stoker-specific terms
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -140,9 +140,7 @@ The key annotations:
 | `stoker.io/cr-name` | `"quickstart"` | Links to the GatewaySync CR |
 | `stoker.io/profile` | `"standard"` | Selects the sync profile from `spec.sync.profiles` |
 
-:::tip Why install the gateway last?
-The Stoker webhook injects the agent sidecar when a pod is created. By installing the operator and CRs first, the webhook is ready to inject on the gateway's first pod creation — no restart needed.
-:::
+The webhook injects on pod creation, so the operator and CRs must be running before the gateway pod starts.
 
 Wait for the gateway to start:
 


### PR DESCRIPTION
### 📖 Background

The docs were written with an implicit audience split: Kubernetes experts on one side, Ignition integrators unfamiliar with Kubernetes on the other. That framing leaked into the text as direct beginner callouts ("If you're an Ignition integrator who hasn't worked with Kubernetes before") and gentle-parenting structures ("Why install the gateway last?"). The effect is patronizing for anyone reading the docs, regardless of their background.

### ⚙️ Changes

**`docs/docs/overview/concepts.md`** (primary focus):
- Removed the flagged line: "If you're an Ignition integrator who hasn't worked with Kubernetes before, these are the terms you'll encounter throughout the docs." — dropped entirely; the section heading and table are self-evident.
- Rewrote the opening paragraph to state what the page does, not who it's for or what they might be missing.
- Replaced the kubectl analogy ("Equivalent to using the Ignition Gateway Webpage, but via terminal commands") with a direct description of what kubectl does in this guide. The analogy assumed K8s ignorance; the replacement is accurate for any reader.
- Updated the frontmatter description to match the new framing.

**`docs/docs/quickstart.md`**:
- Removed the "Why install the gateway last?" tip box. The rhetorical question framed the reader as someone confused by the step ordering. Replaced with a single direct sentence that states the constraint and keeps the useful "must be running before the gateway pod starts" context.

### 📝 Reviewer Notes

Scope is intentionally narrow: tone/condescension only. Em dash removal and broader verbosity trimming are on a parallel branch. These edits should merge cleanly.

All edits preserve technical accuracy. The Kubernetes concepts table content (analogies like "Similar to folders") was left intact — those are explanatory scaffolding, not condescension. Only the explicit capability-gap callouts and reader-flagging language were changed.

### ☑️ Testing Notes

- `cd docs && npm run build` passes (confirmed locally before push).
- Spot-check: concepts.md renders correctly with the section heading leading directly into the table, no orphaned prose between them.