### PR TITLE
docs: remove non-essential em dashes and align prose voice

### DIFF
--- a/docs/docs/guides/content-templating.md
+++ b/docs/docs/guides/content-templating.md
@@ -6,7 +6,7 @@ description: Resolve gateway-specific values inside synced file contents at sync
 
 # Content Templating
 
-Content templating lets the agent resolve Go template variables **inside file contents** as files are staged — without modifying source files in git. This solves the most common multi-site problem: each gateway needs subtly different configuration (system name, remote gateway URLs, historian settings) but maintaining one file per gateway in git doesn't scale.
+Content templating lets the agent resolve Go template variables **inside file contents** as files are staged, without modifying source files in git. This solves the most common multi-site problem: each gateway needs subtly different configuration (system name, remote gateway URLs, historian settings) but maintaining one file per gateway in git doesn't scale.
 
 ## How it works
 
@@ -158,25 +158,25 @@ spec:
             type: dir
 ```
 
-The `{{.Vars.deploymentMode}}` in the **source path** selects `config/overlays/frontend/` from git — a directory that only exists for this profile. The destination path separates overlays from core config so Ignition reads from both directories at runtime.
+The `{{.Vars.deploymentMode}}` in the **source path** selects `config/overlays/frontend/` from git, a directory that only exists for this profile. The destination path separates overlays from core config so Ignition reads from both directories at runtime.
 
 ## Alternative: JSON patches for targeted field updates
 
-If you only need to update a few specific fields in JSON files — rather than authoring full `{{...}}` syntax in the source — consider [JSON Patches](./json-patches.md) instead. Patches are more surgical: you specify an sjson dot-notation path and the value to set, and the agent applies the change after staging without touching the rest of the file.
+To update only a few specific fields without authoring `{{...}}` syntax in source files, use [JSON Patches](./json-patches.md) instead. Specify an sjson dot-notation path and value; the agent applies the change after staging without touching the rest of the file.
 
 | Approach | When to use |
 |----------|-------------|
 | `template: true` | Source files are authored with `{{...}}` syntax; works on any text format |
 | `patches` | You want to override specific JSON field values without modifying source files |
 
-Both can be used on the same mapping — `template: true` runs first, then patches are applied.
+Both can be used on the same mapping: `template: true` runs first, then patches are applied.
 
 ## Binary file protection
 
 Files containing null bytes (`\x00`) are **rejected with an error** when `template: true` is set. This prevents accidental corruption of images, compiled modules, or other binary files.
 
 If a mapping includes both text and binary files, either:
-1. Use separate mappings — one with `template: true` for text, one without for binary files
+1. Use separate mappings: one with `template: true` for text, one without for binary files
 2. Move binary assets to a path excluded by `excludePatterns`
 
 ## Error messages

--- a/docs/docs/guides/git-authentication.md
+++ b/docs/docs/guides/git-authentication.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Git Authentication
 
-Stoker supports three authentication methods for private Git repositories. Public repositories need no auth configuration — just set `spec.git.repo` and `spec.git.ref`.
+Stoker supports three authentication methods for private Git repositories. Public repositories need no auth configuration; just set `spec.git.repo` and `spec.git.ref`.
 
 <Tabs>
 <TabItem value="token" label="Token" default>
@@ -170,7 +170,7 @@ spec:
   # ... gateway, sync config
 ```
 
-**How it works:** The controller exchanges the PEM private key for a short-lived installation access token (1-hour expiry) via the GitHub API, caches it with a 5-minute pre-expiry refresh, and writes it to a controller-managed Secret (`stoker-github-token-{crName}`). The agent mounts this Secret to authenticate git operations. The PEM key never leaves the controller namespace — agent pods do not mount the PEM secret.
+**How it works:** The controller exchanges the PEM private key for a short-lived installation access token (1-hour expiry) via the GitHub API, caches it with a 5-minute pre-expiry refresh, and writes it to a controller-managed Secret (`stoker-github-token-{crName}`). The agent mounts this Secret to authenticate git operations. The PEM key never leaves the controller namespace; agent pods do not mount the PEM secret.
 
 **When to use:** Organizations managing many repos, where individual tokens are impractical or against policy. App tokens auto-rotate and provide audit trails.
 
@@ -191,5 +191,5 @@ Set `apiBaseURL` to your GitHub Enterprise API endpoint (e.g., `https://github.e
 
 ## Next steps
 
-- [GatewaySync CR Reference](../reference/gatewaysync-cr.md#specgitauth) — full auth field reference
-- [Multi-Gateway Profiles](./multi-gateway.md) — route different gateways to different repo paths
+- [GatewaySync CR Reference](../reference/gatewaysync-cr.md#specgitauth): full auth field reference
+- [Multi-Gateway Profiles](./multi-gateway.md): route different gateways to different repo paths

--- a/docs/docs/guides/json-patches.md
+++ b/docs/docs/guides/json-patches.md
@@ -6,13 +6,13 @@ description: Apply targeted JSON field updates at sync time without modifying so
 
 # JSON Patches
 
-JSON patches let the agent surgically update specific fields in JSON files as they are staged — without modifying the source files in git. This is ideal for values that differ per gateway (database hosts, system names, port numbers) when you want precise control over exactly which fields change, rather than treating an entire file as a Go template.
+JSON patches let the agent update specific fields in JSON files at staging time, without modifying source files in git. Use them when per-gateway values (database hosts, system names, port numbers) need to differ and you want surgical control over exactly which fields change, rather than treating an entire file as a Go template.
 
 ## How it works
 
 Add a `patches` block to any mapping. Each patch specifies:
-- **`file`** — which file(s) to patch, expressed as a path relative to the mapping's destination (supports doublestar globs). For file mappings, `file` can be omitted and defaults to the mapped file itself.
-- **`set`** — a map of [sjson-style dot-notation paths](https://github.com/tidwall/sjson#path-syntax) to values. Values may contain Go template syntax (the same variables available in `template: true`).
+- **`file`:** which file(s) to patch, expressed as a path relative to the mapping's destination (supports doublestar globs). For file mappings, `file` can be omitted and defaults to the mapped file itself.
+- **`set`:** a map of [sjson-style dot-notation paths](https://github.com/tidwall/sjson#path-syntax) to values. Values may contain Go template syntax (the same variables available in `template: true`).
 
 The agent copies files from git into staging, then applies patches in-place before writing to `/ignition-data/`. Source files in git are never modified.
 
@@ -26,7 +26,7 @@ The agent copies files from git into staging, then applies patches in-place befo
 | Updating database hosts, system names, ports in JSON | **`patches`** |
 | Files mix binary and text (images alongside JSON) | **`patches`** on JSON only |
 
-`patches` only works on valid JSON files and will error on anything else — including files that fail JSON parsing. `template: true` works on any text file but requires `{{...}}` syntax to already be in the source.
+`patches` only works on valid JSON files and will error on anything else, including files that fail JSON parsing. `template: true` works on any text file but requires `{{...}}` syntax to already be in the source.
 
 ## Patch value type inference
 
@@ -40,7 +40,7 @@ Patch values are resolved as Go templates first, then type-inferred before being
 | `"my-gateway"` | string (fallback) | `"my-gateway"` |
 | `"null"` | null | `null` |
 
-This means you can set boolean flags, numeric ports, and string values without quoting — just write the value you want.
+This means you can set boolean flags, numeric ports, and string values without quoting: just write the value you want.
 
 ## Examples
 
@@ -102,7 +102,7 @@ Every `.json` file in `config/db-connections/` gets its `host` and `port` fields
 
 ### Multiple patches on one mapping
 
-A single mapping can carry multiple patch blocks — each targets different files or sets different fields:
+A single mapping can carry multiple patch blocks, each targeting different files or setting different fields:
 
 ```yaml
 mappings:
@@ -150,7 +150,7 @@ Profile-level `vars` override default `vars` per-key, so you can have a developm
 ## Type inference
 
 :::note
-The `type` field in a mapping is optional. When omitted, the agent calls `os.Stat` on the source path at sync time to determine whether it is a file or directory. If you specify `type`, it is validated against the filesystem — a mismatch produces an error. If the source path does not exist and `required: false`, the agent falls back to `"dir"` and skips the mapping silently.
+The `type` field in a mapping is optional. When omitted, the agent calls `os.Stat` on the source path at sync time to determine whether it is a file or directory. If you specify `type`, it is validated against the filesystem; a mismatch produces an error. If the source path does not exist and `required: false`, the agent falls back to `"dir"` and skips the mapping silently.
 :::
 
 ## sjson path syntax
@@ -164,7 +164,7 @@ Paths follow [tidwall/sjson](https://github.com/tidwall/sjson#path-syntax) dot-n
 | `networkInterfaces.0.address` | Array element by index |
 | `tags.-1` | Append to array |
 
-Paths are case-sensitive. Keys containing `.` or special characters must be escaped — see the sjson docs for details.
+Paths are case-sensitive. Keys containing `.` or special characters must be escaped. See the sjson docs for details.
 
 ## Patches and `template: true` together
 

--- a/docs/docs/guides/monitoring.md
+++ b/docs/docs/guides/monitoring.md
@@ -88,10 +88,10 @@ Two pre-built dashboards are shipped in the Helm chart under `dashboards/`:
 
 | Dashboard | File | Description |
 |-----------|------|-------------|
-| **Fleet Overview** | `stoker-fleet.json` | High-level health across all GatewaySync CRs — summary stats, per-CR status cards with drill-down links, CR info table, controller performance, agent averages, webhook rates |
-| **GatewaySync Detail** | `stoker-detail.json` | Deep dive into a single CR — conditions, per-gateway status table, controller and agent performance, file breakdown, designer sessions |
+| **Fleet Overview** | `stoker-fleet.json` | High-level health across all GatewaySync CRs: summary stats, per-CR status cards with drill-down links, CR info table, controller performance, agent averages, webhook rates |
+| **GatewaySync Detail** | `stoker-detail.json` | Deep dive into a single CR: conditions, per-gateway status table, controller and agent performance, file breakdown, designer sessions |
 
-The fleet dashboard links to the detail view — click any CR status card to drill down with the namespace and CR pre-populated.
+The fleet dashboard links to the detail view; click any CR status card to drill down with the namespace and CR pre-populated.
 
 ### Auto-provisioning via sidecar
 
@@ -119,15 +119,15 @@ For Grafana instances without the sidecar (standalone, Docker, Grafana Cloud), c
 ### Dashboard variables
 
 The **fleet dashboard** has two variables:
-- `datasource` — Prometheus data source
-- `namespace` — multi-select filter for CR namespaces (defaults to All)
+- `datasource`: Prometheus data source
+- `namespace`: multi-select filter for CR namespaces (defaults to All)
 
 The **detail dashboard** has five variables:
-- `datasource` — Prometheus data source
-- `namespace` — single CR namespace (from controller metrics)
-- `cr` — single GatewaySync CR name
-- `agent_namespace` — multi-select filter for agent pod namespaces (separate from CR namespace since agents run in gateway namespaces)
-- `profile` — multi-select filter for sync profiles
+- `datasource`: Prometheus data source
+- `namespace`: single CR namespace (from controller metrics)
+- `cr`: single GatewaySync CR name
+- `agent_namespace`: multi-select filter for agent pod namespaces (separate from CR namespace since agents run in gateway namespaces)
+- `profile`: multi-select filter for sync profiles
 
 :::tip
 Controller metrics use `namespace` = the CR's namespace. Agent metrics use `namespace` = the gateway pod's namespace. These are typically different namespaces. The dashboards handle this with separate template variables.

--- a/docs/docs/guides/multi-gateway.md
+++ b/docs/docs/guides/multi-gateway.md
@@ -27,7 +27,7 @@ spec:
             type: dir
 ```
 
-A gateway named `ignition-blue` syncs from `services/ignition-blue/`, while `ignition-red` syncs from `services/ignition-red/` — same profile, different files.
+A gateway named `ignition-blue` syncs from `services/ignition-blue/`, while `ignition-red` syncs from `services/ignition-red/`: same profile, different files.
 
 ## Label-based routing
 
@@ -59,7 +59,7 @@ podLabels:
 Now this gateway syncs from `sites/factory-north/`.
 
 :::warning Label key naming
-`key` in `{{.Labels.key}}` must be a **valid identifier** — letters, digits, and underscores only. **Dashes and dots are not supported** and cause a template parse error at sync time.
+`key` in `{{.Labels.key}}` must be a **valid identifier**: letters, digits, and underscores only. **Dashes and dots are not supported** and cause a template parse error at sync time.
 
 | | |
 |---|---|
@@ -90,7 +90,7 @@ spec:
 ```
 
 :::warning Var key naming
-Var keys follow the same identifier constraint as label keys — **letters, digits, and underscores only; no dashes**. The controller rejects CRs with invalid var keys immediately at reconcile time with a `ProfilesValid=False` status condition, so you'll catch errors before they reach sync.
+Var keys follow the same identifier constraint as label keys: **letters, digits, and underscores only; no dashes**. The controller rejects CRs with invalid var keys immediately at reconcile time with a `ProfilesValid=False` status condition, so you'll catch errors before they reach sync.
 
 | | |
 |---|---|
@@ -209,9 +209,9 @@ spec:
 |----------|--------|---------------|
 | `{{.GatewayName}}` | `stoker.io/gateway-name` annotation or `app.kubernetes.io/name` label | `ignition-blue` |
 | `{{.PodName}}` | Kubernetes pod name | `my-gateway-0` |
-| `{{.PodOrdinal}}` | StatefulSet replica index — from `apps.kubernetes.io/pod-index` label (K8s 1.27+), falls back to parsing pod name | `0`, `1`, `2` |
-| `{{.Labels.key}}` | Any pod label — key must be a valid identifier (no dashes) | `factory-north` |
-| `{{.Vars.key}}` | Profile or defaults `vars` map — key must be a valid identifier (no dashes) | `us-east` |
+| `{{.PodOrdinal}}` | StatefulSet replica index: from `apps.kubernetes.io/pod-index` label (K8s 1.27+), falls back to parsing pod name | `0`, `1`, `2` |
+| `{{.Labels.key}}` | Any pod label; key must be a valid identifier (no dashes) | `factory-north` |
+| `{{.Vars.key}}` | Profile or defaults `vars` map; key must be a valid identifier (no dashes) | `us-east` |
 | `{{.CRName}}` | GatewaySync CR name | `my-sync` |
 | `{{.Namespace}}` | Pod namespace | `production` |
 | `{{.Ref}}` | Resolved git ref | `main` |
@@ -221,5 +221,5 @@ See the [CRD reference](../reference/gatewaysync-cr.md#template-variables) for t
 
 ## Next steps
 
-- [GatewaySync CR Reference](../reference/gatewaysync-cr.md#template-variables) — full template variable reference
-- [Webhook Sync](./webhook-sync.md) — trigger instant syncs on push events
+- [GatewaySync CR Reference](../reference/gatewaysync-cr.md#template-variables): full template variable reference
+- [Webhook Sync](./webhook-sync.md): trigger instant syncs on push events

--- a/docs/docs/guides/multi-site-deployment.md
+++ b/docs/docs/guides/multi-site-deployment.md
@@ -6,7 +6,7 @@ description: Run Stoker across multiple sites or environments with per-gateway c
 
 # Multi-Site Deployment
 
-This guide covers the patterns for deploying Stoker across multiple sites, environments, or regions — where each gateway needs unique configuration while sharing most of the repository structure.
+This guide covers the patterns for deploying Stoker across multiple sites, environments, or regions, where each gateway needs unique configuration while sharing most of the repository structure.
 
 ## The problem: unique systemName
 
@@ -14,8 +14,8 @@ Every Ignition gateway requires a unique `systemName` in `config/resources/local
 
 Stoker solves this in two ways depending on whether you prefer to modify source files or not:
 
-- **Content templating** (`template: true`) — author `{{.GatewayName}}` directly in the JSON source file. See the [Content Templating guide](./content-templating.md).
-- **JSON patches** (`patches`) — keep source files unmodified in git; the agent sets `systemName` at sync time using a dot-notation path. See the [JSON Patches guide](./json-patches.md).
+- **Content templating** (`template: true`): author `{{.GatewayName}}` directly in the JSON source file. See the [Content Templating guide](./content-templating.md).
+- **JSON patches** (`patches`): keep source files unmodified in git; the agent sets `systemName` at sync time using a dot-notation path. See the [JSON Patches guide](./json-patches.md).
 
 ### Patches approach (source file unchanged)
 

--- a/docs/docs/guides/webhook-sync.md
+++ b/docs/docs/guides/webhook-sync.md
@@ -30,7 +30,7 @@ helm upgrade stoker oci://ghcr.io/ia-eknorr/charts/stoker-operator \
 
 The controller runs an HTTP server (port 9444) that accepts webhook payloads. When a payload arrives, the receiver:
 
-1. Validates auth (if configured — HMAC or bearer token, first match wins)
+1. Validates auth (HMAC or bearer token if configured; first match wins)
 2. Extracts the ref from the payload (auto-detects format)
 3. Annotates the GatewaySync CR with the requested ref
 4. The controller's reconciliation predicate detects the annotation change and triggers an immediate sync
@@ -41,8 +41,8 @@ The controller runs an HTTP server (port 9444) that accepts webhook payloads. Wh
 POST /webhook/{namespace}/{crName}
 ```
 
-- `{namespace}` — the namespace of the GatewaySync CR
-- `{crName}` — the name of the GatewaySync CR
+- `{namespace}`: the namespace of the GatewaySync CR
+- `{crName}`: the name of the GatewaySync CR
 
 When `webhookReceiver.enabled` is true, the Helm chart creates a Service for the webhook receiver automatically.
 
@@ -79,7 +79,7 @@ kubectl port-forward -n stoker-system svc/stoker-stoker-operator-webhook-receive
 
 ## Payload formats
 
-The receiver auto-detects the payload format. No configuration needed — just point your webhook at the endpoint.
+The receiver auto-detects the payload format. No configuration needed.
 
 ### GitHub release
 
@@ -136,7 +136,7 @@ Configure at least one auth method for production. If both are set, either metho
 
 ### HMAC (GitHub-compatible)
 
-HMAC validates the `X-Hub-Signature-256` header — the standard used by GitHub webhooks. Use this when your sender can compute signatures (GitHub, custom senders).
+HMAC validates the `X-Hub-Signature-256` header, the standard used by GitHub webhooks. Use this when your sender can compute signatures (GitHub, custom senders).
 
 ```yaml
 webhookReceiver:
@@ -149,7 +149,7 @@ webhookReceiver:
 
 ### Bearer token
 
-Any HTTP client that can set headers can authenticate with a static bearer token. The receiver validates the `Authorization: Bearer <token>` header — no signature computation required.
+Any HTTP client that can set headers can authenticate with a static bearer token. The receiver validates the `Authorization: Bearer <token>` header; no signature computation required.
 
 ```yaml
 webhookReceiver:
@@ -211,5 +211,5 @@ spec:
 
 ## Next steps
 
-- [Helm Values](../reference/helm-values.md#push-receiver-webhook) — webhook receiver configuration
-- [Annotations Reference](../reference/annotations.md) — CR annotations set by the receiver
+- [Helm Values](../reference/helm-values.md#push-receiver-webhook): webhook receiver configuration
+- [Annotations Reference](../reference/annotations.md): CR annotations set by the receiver

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -38,7 +38,7 @@ You should see a `controller-manager` pod in `Running` state.
 
 ## Enable sidecar injection
 
-Sidecar injection is enabled by default in all namespaces (except `kube-system` and `kube-node-lease`). Any pod with annotation `stoker.io/inject: "true"` will receive the agent sidecar — no namespace label is needed.
+Sidecar injection is enabled by default in all namespaces (except `kube-system` and `kube-node-lease`). Any pod with annotation `stoker.io/inject: "true"` will receive the agent sidecar; no namespace label is needed.
 
 For regulated environments that require explicit namespace opt-in (e.g., IEC 62443 zone boundaries), enable the namespace label requirement:
 

--- a/docs/docs/overview/architecture.md
+++ b/docs/docs/overview/architecture.md
@@ -6,7 +6,7 @@ description: Controller, webhook, and agent architecture overview.
 
 # Architecture
 
-Stoker uses a **controller + agent sidecar** architecture. The controller runs as a Deployment, while each gateway pod gets an agent sidecar injected automatically. There is no shared storage — all communication flows through ConfigMaps.
+Stoker uses a **controller + agent sidecar** architecture. The controller runs as a Deployment, while each gateway pod gets an agent sidecar injected automatically. There is no shared storage; all communication flows through ConfigMaps.
 
 ## Components
 
@@ -34,10 +34,10 @@ flowchart LR
 
 The controller reconciles `GatewaySync` custom resources. On each reconciliation it:
 
-1. **Resolves the Git ref** — calls `git ls-remote` to translate a branch or tag name to a commit SHA. This requires no clone and no persistent storage.
-2. **Discovers gateway pods** — finds pods in the same namespace with the `stoker.io/cr-name` annotation matching this CR.
-3. **Writes metadata ConfigMaps** — writes the resolved ref, commit, auth type, mappings, and profile configuration to `stoker-metadata-{crName}`.
-4. **Aggregates status** — reads `stoker-status-{crName}` ConfigMaps written by agents and surfaces per-gateway sync status on the CR.
+1. **Resolves the Git ref:** calls `git ls-remote` to translate a branch or tag name to a commit SHA. This requires no clone and no persistent storage.
+2. **Discovers gateway pods:** finds pods in the same namespace with the `stoker.io/cr-name` annotation matching this CR.
+3. **Writes metadata ConfigMaps:** writes the resolved ref, commit, auth type, mappings, and profile configuration to `stoker-metadata-{crName}`.
+4. **Aggregates status:** reads `stoker-status-{crName}` ConfigMaps written by agents and surfaces per-gateway sync status on the CR.
 
 When `rbac.autoBindAgent.enabled` is true (default), the controller also creates a `RoleBinding` in the CR's namespace binding discovered gateway ServiceAccounts to the `stoker-agent` ClusterRole. The binding uses an `ownerReference` pointing to the GatewaySync CR, so it is automatically garbage-collected when the CR is deleted.
 
@@ -45,7 +45,7 @@ The controller uses a custom predicate that triggers reconciliation on spec gene
 
 ### Mutating webhook
 
-The webhook intercepts pod creation and injects the agent as a **native sidecar** — an init container with `restartPolicy: Always` (requires Kubernetes 1.28+). Injection requires one condition:
+The webhook intercepts pod creation and injects the agent as a **native sidecar**: an init container with `restartPolicy: Always` (requires Kubernetes 1.28+). Injection requires one condition:
 
 1. **Pod annotation:** `stoker.io/inject: "true"`
 
@@ -66,13 +66,13 @@ flowchart LR
     E --> F[Write status\nConfigMap]
 ```
 
-1. **Read** — reads the metadata ConfigMap to get the current ref, commit, mappings, and profile config
-2. **Clone** — clones the repo to a local emptyDir at `/repo`
-3. **Build plan & stage** — resolves template variables, computes file changes, copies to `/ignition-data/.sync-staging/`
-4. **Merge** — moves staged files to the live `/ignition-data/` directory
-5. **Clean** — removes orphaned files within managed paths only (won't touch unmanaged directories)
-6. **Scan** — calls the Ignition REST API (`/scan/projects` and `/scan/config`) so the gateway reloads without restart
-7. **Report** — writes sync results (commit, file counts, errors) to the status ConfigMap
+1. **Read:** reads the metadata ConfigMap to get the current ref, commit, mappings, and profile config
+2. **Clone:** clones the repo to a local emptyDir at `/repo`
+3. **Build plan & stage:** resolves template variables, computes file changes, copies to `/ignition-data/.sync-staging/`
+4. **Merge:** moves staged files to the live `/ignition-data/` directory
+5. **Clean:** removes orphaned files within managed paths only (won't touch unmanaged directories)
+6. **Scan:** calls the Ignition REST API (`/scan/projects` and `/scan/config`) so the gateway reloads without restart
+7. **Report:** writes sync results (commit, file counts, errors) to the status ConfigMap
 
 #### Three-layer architecture
 
@@ -80,7 +80,7 @@ The agent is split into three layers to keep concerns separate:
 
 | Layer | Package | Aware of |
 |-------|---------|----------|
-| **Sync engine** | `internal/syncengine` | File operations only — takes a plan, copies files |
+| **Sync engine** | `internal/syncengine` | File operations only: takes a plan, copies files |
 | **Agent orchestrator** | `internal/agent` | Kubernetes (reads ConfigMaps, writes status, emits events) |
 | **Ignition client** | `internal/ignition` | Ignition API (scan endpoints, health check, designer sessions) |
 
@@ -99,7 +99,7 @@ This design means no shared PVC is needed, and agents can run in any pod without
 
 ## Webhook receiver
 
-The controller can optionally run an HTTP server on port 9444 that accepts push-event webhooks. The receiver is **disabled by default** — enable it with `webhookReceiver.enabled: true` in the Helm values.
+The controller can optionally run an HTTP server on port 9444 that accepts push-event webhooks. The receiver is **disabled by default**. Enable it with `webhookReceiver.enabled: true` in the Helm values.
 
 ```
 POST /webhook/{namespace}/{crName}
@@ -111,7 +111,7 @@ HMAC signature validation via `X-Hub-Signature-256` is supported when configured
 
 ## Next steps
 
-- [Quickstart](../quickstart.md) — get started with a working example
-- [Git Authentication](../guides/git-authentication.md) — set up auth for private repos
-- [Monitoring](../guides/monitoring.md) — Prometheus metrics and Grafana dashboards
-- [GatewaySync CR Reference](../reference/gatewaysync-cr.md) — full spec reference
+- [Quickstart](../quickstart.md): get started with a working example
+- [Git Authentication](../guides/git-authentication.md): set up auth for private repos
+- [Monitoring](../guides/monitoring.md): Prometheus metrics and Grafana dashboards
+- [GatewaySync CR Reference](../reference/gatewaysync-cr.md): full spec reference

--- a/docs/docs/overview/concepts.md
+++ b/docs/docs/overview/concepts.md
@@ -15,17 +15,17 @@ If you're an Ignition integrator who hasn't worked with Kubernetes before, these
 | Term | What it means |
 |------|--------------|
 | **Cluster** | A set of machines (nodes) running Kubernetes. Think of it as the infrastructure that hosts your gateways. |
-| **Namespace** | A logical partition within a cluster. Similar to folders — you might have `production` and `staging` namespaces for different environments. |
+| **Namespace** | A logical partition within a cluster. Similar to folders; you might have `production` and `staging` namespaces for different environments. |
 | **Pod** | The smallest deployable unit in Kubernetes. A pod runs one or more containers. Your Ignition gateway runs inside a pod. |
 | **Sidecar** | An extra container that runs alongside your main container in the same pod. Stoker's sync agent runs as a sidecar next to the Ignition gateway container. |
-| **Operator** | A program that watches for custom resources and takes action. Stoker's controller is an operator — it watches `GatewaySync` resources and manages sync behavior. |
+| **Operator** | A program that watches for custom resources and takes action. Stoker's controller is an operator: it watches `GatewaySync` resources and manages sync behavior. |
 | **Custom Resource (CR)** | An extension of the Kubernetes API. `GatewaySync` is a custom resource that you create to tell Stoker what to sync and how. |
 | **CRD (Custom Resource Definition)** | The schema that defines a custom resource type. The `GatewaySync` CRD tells Kubernetes what fields are valid. |
 | **ConfigMap** | A Kubernetes object that stores key-value configuration data. Stoker uses ConfigMaps to pass metadata from the controller to agents and to collect sync status. |
 | **Annotation** | A key-value label attached to a Kubernetes object for metadata. Stoker uses annotations like `stoker.io/inject: "true"` to control which pods get the agent sidecar. |
 | **Label** | Similar to annotations but used for selection and filtering. Gateway pods use labels like `app.kubernetes.io/name` for discovery. |
 | **Helm** | A package manager for Kubernetes. Stoker is installed via a Helm chart that templates all the Kubernetes resources. |
-| **MutatingWebhook** | A Kubernetes feature that intercepts object creation and modifies it. Stoker's webhook automatically injects the agent sidecar into gateway pods — you don't configure the sidecar manually. |
+| **MutatingWebhook** | A Kubernetes feature that intercepts object creation and modifies it. Stoker's webhook automatically injects the agent sidecar into gateway pods; no manual sidecar configuration needed. |
 | **RBAC (Role-Based Access Control)** | Kubernetes permission system. The agent sidecar needs permissions to read ConfigMaps in its namespace. |
 | **kubectl** | The command-line tool for interacting with a Kubernetes cluster. Equivalent to using the Ignition Gateway Webpage, but via terminal commands. |
 
@@ -38,10 +38,10 @@ These terms are specific to Stoker and appear throughout the documentation.
 | **GatewaySync** | The custom resource (CR) you create to define a sync. It specifies the Git repo, ref, authentication, gateway settings, and sync profiles. Short name: `gs`. |
 | **Profile** | A named set of file mappings within a GatewaySync CR. Different gateways can use different profiles to get different subsets of the repo. Selected by the `stoker.io/profile` pod annotation. |
 | **Mapping** | A source-to-destination rule inside a profile. For example, `source: "projects/"` → `destination: "projects/"` copies the `projects/` directory from Git to the gateway's data directory. |
-| **Template variable** | Placeholders like `{{.GatewayName}}`, `{{.PodOrdinal}}`, or `{{.Vars.key}}` in mapping paths and patch values. Resolved per-gateway at sync time so one profile can route different files to different gateways. Label and var keys must be valid identifiers (letters, digits, underscores — no dashes). |
+| **Template variable** | Placeholders like `{{.GatewayName}}`, `{{.PodOrdinal}}`, or `{{.Vars.key}}` in mapping paths and patch values. Resolved per-gateway at sync time so one profile can route different files to different gateways. Label and var keys must be valid identifiers (letters, digits, underscores; no dashes). |
 | **Ref resolution** | The process of converting a branch name or tag to a specific Git commit SHA via `git ls-remote`. The controller does this without cloning the repo. |
-| **Metadata ConfigMap** | `stoker-metadata-{crName}` — written by the controller, read by agents. Contains the resolved ref, commit, auth type, and profile mappings. |
-| **Status ConfigMap** | `stoker-status-{crName}` — written by agents, read by the controller. Contains per-gateway sync results, error messages, and file change counts. |
+| **Metadata ConfigMap** | `stoker-metadata-{crName}`: written by the controller, read by agents. Contains the resolved ref, commit, auth type, and profile mappings. |
+| **Status ConfigMap** | `stoker-status-{crName}`: written by agents, read by the controller. Contains per-gateway sync results, error messages, and file change counts. |
 | **Webhook receiver** | An HTTP endpoint (`POST /webhook/{namespace}/{crName}`) that accepts push events from GitHub, ArgoCD, Kargo, or any system that sends JSON. Triggers an immediate sync instead of waiting for the poll interval. |
 | **Native sidecar** | A Kubernetes 1.28+ feature where init containers can have `restartPolicy: Always`, making them run alongside the main container for the pod's lifetime. Stoker uses this for the agent. |
 

--- a/docs/docs/overview/introduction.md
+++ b/docs/docs/overview/introduction.md
@@ -6,7 +6,7 @@ description: What is Stoker and why it exists.
 
 # Introduction
 
-Stoker is a Kubernetes operator that continuously syncs Ignition SCADA gateway configuration from Git. Declare your desired gateway state — projects, themes, config files — in a Git repository, and Stoker keeps every gateway in sync automatically.
+Stoker is a Kubernetes operator that continuously syncs Ignition SCADA gateway configuration from Git. Declare your desired gateway state (projects, themes, config files) in a Git repository, and Stoker keeps every gateway in sync automatically.
 
 ## The problem
 
@@ -18,13 +18,13 @@ Stoker brings GitOps to Ignition. You commit configuration to a Git repository a
 
 ## Key features
 
-- **Git-driven sync** — branch, tag, or commit SHA as the source of truth
-- **Multi-gateway profiles** — one CR can serve many gateways using template variables (`{{.GatewayName}}`, `{{.Labels.site}}`)
-- **Automatic sidecar injection** — a mutating webhook injects the sync agent with zero manual container config
-- **Webhook-driven sync** — trigger instant syncs from GitHub releases, ArgoCD, Kargo, or any system that can POST JSON
-- **Dry-run mode** — preview file changes in a status ConfigMap before touching the live directory
-- **Designer session awareness** — proceed, wait, or abort when designers are connected
-- **No shared storage** — controller and agent communicate entirely via ConfigMaps
+- **Git-driven sync:** branch, tag, or commit SHA as the source of truth
+- **Multi-gateway profiles:** one CR can serve many gateways using template variables (`{{.GatewayName}}`, `{{.Labels.site}}`)
+- **Automatic sidecar injection:** a mutating webhook injects the sync agent with zero manual container config
+- **Webhook-driven sync:** trigger instant syncs from GitHub releases, ArgoCD, Kargo, or any system that can POST JSON
+- **Dry-run mode:** preview file changes in a status ConfigMap before touching the live directory
+- **Designer session awareness:** proceed, wait, or abort when designers are connected
+- **No shared storage:** controller and agent communicate entirely via ConfigMaps
 
 ## How it works
 
@@ -54,5 +54,5 @@ Stoker brings GitOps to Ignition. You commit configuration to a Git repository a
 
 ## Next steps
 
-- [Architecture](./architecture.md) — deep dive into the controller, webhook, and agent
-- [Quickstart](../quickstart.md) — get a gateway syncing from Git in 5 steps
+- [Architecture](./architecture.md): deep dive into the controller, webhook, and agent
+- [Quickstart](../quickstart.md): get a gateway syncing from Git in 5 steps

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -42,7 +42,7 @@ You should see a `controller-manager` pod in `Running` state.
 
 ## 2. Create secrets
 
-This quickstart uses [`ia-eknorr/test-ignition-project`](https://github.com/ia-eknorr/test-ignition-project), a public example repository created for this guide. It contains an Ignition stack with two gateway configurations — `ignition-blue` and `ignition-red` — each with their own projects and config directories. We'll sync `ignition-blue` to a single gateway.
+This quickstart uses [`ia-eknorr/test-ignition-project`](https://github.com/ia-eknorr/test-ignition-project), a public example repository created for this guide. It contains an Ignition stack with two gateway configurations (`ignition-blue` and `ignition-red`), each with their own projects and config directories. We'll sync `ignition-blue` to a single gateway.
 
 Create a namespace and a secret so the agent can authenticate with the gateway's scan API. The example repository includes a pre-configured API token resource:
 
@@ -53,7 +53,7 @@ kubectl create secret generic gw-api-key -n quickstart \
 ```
 
 :::warning
-This API key is for the example repository only. Never reuse example credentials — [generate unique API tokens](https://www.docs.inductiveautomation.com/docs/8.3/platform/security/api-keys#using-api-keys) for each gateway in your own deployments.
+This API key is for the example repository only. Never reuse example credentials. [Generate unique API tokens](https://www.docs.inductiveautomation.com/docs/8.3/platform/security/api-keys#using-api-keys) for each gateway in your own deployments.
 :::
 
 No git credentials are needed since we're using a public repository.
@@ -141,7 +141,7 @@ The key annotations:
 | `stoker.io/profile` | `"standard"` | Selects the sync profile from `spec.sync.profiles` |
 
 :::tip Why install the gateway last?
-The Stoker webhook injects the agent sidecar when a pod is created. By installing the operator and CRs first, the webhook is ready to inject on the gateway's first pod creation — no restart needed.
+The Stoker webhook injects the agent sidecar when a pod is created. By installing the operator and CRs first, the webhook is ready to inject on the gateway's first pod creation, so no restart is needed.
 :::
 
 Wait for the gateway to start:
@@ -158,7 +158,7 @@ Once the gateway pod shows **2/2**, walk through these checks to confirm everyth
 
 ### Confirm sidecar injection
 
-Verify the pod has both containers — the gateway and the injected `stoker-agent` sidecar:
+Verify the pod has both containers: the gateway and the injected `stoker-agent` sidecar.
 
 ```bash
 kubectl get pod -n quickstart -o 'custom-columns=NAME:.metadata.name,SIDECARS:.spec.initContainers[*].name,STATUS:.status.phase'
@@ -208,9 +208,9 @@ kubectl logs -n quickstart -l app.kubernetes.io/name=ignition -c stoker-agent --
 
 Look for:
 
-- `clone complete` — the repo was cloned successfully
-- `initial sync complete, startup probe now passing` — files were delivered before the gateway started
-- `new commit detected` — the agent saw a commit change and will sync
+- `clone complete`: the repo was cloned successfully
+- `initial sync complete, startup probe now passing`: files were delivered before the gateway started
+- `new commit detected`: the agent saw a commit change and will sync
 
 In steady state, agent logs are silent when nothing changes. To see detailed sync activity (file counts, scan results), increase the log verbosity with `--zap-log-level=1` or set `LOG_LEVEL=debug`.
 
@@ -264,8 +264,8 @@ kind delete cluster --name stoker-quickstart
 
 ## Next steps
 
-- **[Multi-Gateway Profiles](./guides/multi-gateway.md)** — use `{{.GatewayName}}` or `{{.Labels.key}}` to serve multiple gateways from one profile
-- **[Webhook Sync](./guides/webhook-sync.md)** — trigger syncs on git push events instead of polling
-- **[Git Authentication](./guides/git-authentication.md)** — set up token, SSH, or GitHub App auth for private repositories
-- **[GatewaySync CR Reference](./reference/gatewaysync-cr.md)** — full spec reference including git auth, polling, sync profiles, and agent configuration
-- **[Helm Values](./reference/helm-values.md)** — all configurable values for the operator chart
+- **[Multi-Gateway Profiles](./guides/multi-gateway.md):** use `{{.GatewayName}}` or `{{.Labels.key}}` to serve multiple gateways from one profile
+- **[Webhook Sync](./guides/webhook-sync.md):** trigger syncs on git push events instead of polling
+- **[Git Authentication](./guides/git-authentication.md):** set up token, SSH, or GitHub App auth for private repositories
+- **[GatewaySync CR Reference](./reference/gatewaysync-cr.md):** full spec reference including git auth, polling, sync profiles, and agent configuration
+- **[Helm Values](./reference/helm-values.md):** all configurable values for the operator chart

--- a/docs/docs/reference/annotations.md
+++ b/docs/docs/reference/annotations.md
@@ -36,7 +36,7 @@ Use `--set-string` (not `--set`) when passing annotation values through Helm to 
 
 | Label | Value | Description |
 |-------|-------|-------------|
-| `stoker.io/injection` | `enabled` | Optional — only needed when `webhook.namespaceSelector.requireLabel=true`. Marks the namespace for sidecar injection. |
+| `stoker.io/injection` | `enabled` | Optional: only needed when `webhook.namespaceSelector.requireLabel=true`. Marks the namespace for sidecar injection. |
 
 ```bash
 kubectl label namespace my-namespace stoker.io/injection=enabled
@@ -50,7 +50,7 @@ These annotations are set automatically on GatewaySync CRs by the webhook receiv
 
 | Annotation | Value | Description |
 |------------|-------|-------------|
-| `stoker.io/requested-ref` | string | Git ref requested by the last webhook payload. Acts as a fast-path override of `spec.git.ref` — the controller uses this value immediately without waiting for ArgoCD to sync. Automatically cleared once `spec.git.ref` catches up (with `v`-prefix normalization). |
+| `stoker.io/requested-ref` | string | Git ref requested by the last webhook payload. Acts as a fast-path override of `spec.git.ref`: the controller uses this value immediately without waiting for ArgoCD to sync. Automatically cleared once `spec.git.ref` catches up (with `v`-prefix normalization). |
 | `stoker.io/requested-at` | RFC 3339 timestamp | When the webhook request was received |
 | `stoker.io/requested-by` | `"github"`, `"argocd"`, `"kargo"`, or `"generic"` | Source format detected from the payload |
 
@@ -60,7 +60,7 @@ These annotations trigger an immediate reconciliation via the controller's predi
 
 | Annotation | Value | Description |
 |------------|-------|-------------|
-| `stoker.io/injected` | `"true"` | Set by the mutating webhook after successful sidecar injection. Used for tracking — do not set manually. |
+| `stoker.io/injected` | `"true"` | Set by the mutating webhook after successful sidecar injection. Used for tracking; do not set manually. |
 
 ## Annotations and labels on owned resources
 

--- a/docs/docs/reference/gatewaysync-cr.md
+++ b/docs/docs/reference/gatewaysync-cr.md
@@ -65,7 +65,7 @@ spec:
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `repo` | string | Yes | — | Git repository URL (SSH or HTTPS) |
-| `ref` | string | Yes | — | Git reference to sync — branch, tag, or commit SHA |
+| `ref` | string | Yes | — | Git reference to sync: branch, tag, or commit SHA |
 | `auth` | object | No | — | Git authentication configuration |
 
 ### `spec.git.auth`
@@ -131,7 +131,7 @@ auth:
 | `githubApp.privateKeySecretRef.key` | string | Yes | — | Key within the Secret |
 | `githubApp.apiBaseURL` | string | No | `https://api.github.com` | GitHub API base URL (set for GitHub Enterprise Server) |
 
-The controller exchanges the PEM private key for a short-lived installation access token (1-hour expiry), caches it with a 5-minute pre-expiry refresh, and writes it to a controller-managed Secret (`stoker-github-token-{crName}`). The agent mounts this Secret at `/etc/stoker/git-token/token`. The PEM key never leaves the controller namespace — agent pods do not mount the PEM secret.
+The controller exchanges the PEM private key for a short-lived installation access token (1-hour expiry), caches it with a 5-minute pre-expiry refresh, and writes it to a controller-managed Secret (`stoker-github-token-{crName}`). The agent mounts this Secret at `/etc/stoker/git-token/token`. The PEM key never leaves the controller namespace; agent pods do not mount the PEM secret.
 
 ## `spec.polling`
 
@@ -164,10 +164,10 @@ Baseline settings inherited by all profiles. Individual profiles can override th
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `excludePatterns` | []string | No | `["**/.git/", "**/.gitkeep", "**/.resources/**"]` | Glob patterns for files to exclude from sync |
-| `vars` | map[string]string | No | — | Default template variables inherited by all profiles. Profile `vars` override these per-key. Keys must be valid identifiers (letters, digits, underscores — no dashes). |
+| `vars` | map[string]string | No | — | Default template variables inherited by all profiles. Profile `vars` override these per-key. Keys must be valid identifiers (letters, digits, underscores; no dashes). |
 | `syncPeriod` | int32 | No | `30` | Agent-side polling interval in seconds (min: 5, max: 3600) |
 | `designerSessionPolicy` | string | No | `"proceed"` | Behavior when Designer sessions are active: `proceed`, `wait`, or `fail` |
-| `dryRun` | bool | No | `false` | Sync to staging only — write diff to status ConfigMap without modifying `/ignition-data/` |
+| `dryRun` | bool | No | `false` | Sync to staging only; writes the diff to the status ConfigMap without modifying `/ignition-data/` |
 | `paused` | bool | No | `false` | Halt sync for all profiles |
 
 The `**/.resources/**` pattern is always enforced by the agent even if omitted from `excludePatterns`.
@@ -199,7 +199,7 @@ Each profile supports the following fields:
 |-------|------|----------|---------|-------------|
 | `mappings` | []object | Yes | — | Ordered list of source-to-destination file mappings |
 | `excludePatterns` | []string | No | — | Additional glob patterns merged with `spec.sync.defaults.excludePatterns` |
-| `vars` | map[string]string | No | — | Custom template variables available as `{{.Vars.key}}`. Keys must be valid identifiers (letters, digits, underscores — no dashes). |
+| `vars` | map[string]string | No | — | Custom template variables available as `{{.Vars.key}}`. Keys must be valid identifiers (letters, digits, underscores; no dashes). |
 | `syncPeriod` | int32 | No | inherited | Overrides `spec.sync.defaults.syncPeriod` |
 | `dryRun` | bool | No | inherited | Overrides `spec.sync.defaults.dryRun` |
 | `designerSessionPolicy` | string | No | inherited | Overrides `spec.sync.defaults.designerSessionPolicy` |
@@ -213,13 +213,13 @@ An ordered list of source-to-destination file mappings. Applied top to bottom; l
 |-------|------|----------|---------|-------------|
 | `source` | string | Yes | — | Repo-relative path to copy from |
 | `destination` | string | Yes | — | Path relative to the Ignition data directory (`/ignition-data/`) |
-| `type` | string | No | inferred | Entry type — `"dir"` or `"file"`. When omitted the agent infers the type from the filesystem at sync time. |
+| `type` | string | No | inferred | Entry type: `"dir"` or `"file"`. When omitted the agent infers the type from the filesystem at sync time. |
 | `required` | bool | No | `false` | Fail sync if the source path doesn't exist |
 | `template` | bool | No | `false` | Resolve Go template variables inside file **contents** at sync time. Binary files (null bytes) are rejected. See [Content Templating](../guides/content-templating.md). |
 | `patches` | []object | No | — | Targeted JSON field updates applied at sync time. See [JSON Patches](../guides/json-patches.md). |
 
 :::note
-`type` is inferred from `os.Stat` on the source path — no default value is required in the CR. If you set it explicitly, it acts as a validation hint: the agent errors if the actual filesystem type doesn't match. A source that doesn't exist (when `required: false`) defaults to `"dir"` and is silently skipped.
+`type` is inferred from `os.Stat` on the source path; no default value is required in the CR. If you set it explicitly, it acts as a validation hint: the agent errors if the actual filesystem type doesn't match. A source that doesn't exist (when `required: false`) defaults to `"dir"` and is silently skipped.
 :::
 
 #### `patches`
@@ -257,7 +257,7 @@ Both `source` and `destination` support Go template variables:
 | `{{.PodName}}` | Kubernetes pod name | `system-{{.PodName}}` |
 | `{{.PodOrdinal}}` | StatefulSet replica index (`0`, `1`, `2`, ...). Always `0` for non-StatefulSet pods. Sourced from the `apps.kubernetes.io/pod-index` label (K8s 1.27+) with pod-name fallback. | `"{{.Vars.projectName}}-{{.PodOrdinal}}"` |
 | `{{.CRName}}` | Name of the GatewaySync CR that owns this sync | `config/{{.CRName}}/resources` |
-| `{{.Labels.key}}` | Any label on the gateway pod — `key` must be a simple identifier (letters, digits, underscores). See note below. | `sites/{{.Labels.site}}/projects` |
+| `{{.Labels.key}}` | Any label on the gateway pod. `key` must be a simple identifier (letters, digits, underscores). See note below. | `sites/{{.Labels.site}}/projects` |
 | `{{.Vars.key}}` | Custom variable from profile or defaults `vars` (profile overrides default per-key) | `site{{.Vars.siteNumber}}/scripts` |
 | `{{.Namespace}}` | Pod namespace | `config/{{.Namespace}}/overlay` |
 | `{{.Ref}}` | Resolved git ref | — |
@@ -287,7 +287,7 @@ sync:
                 # → my-gateway-0, my-gateway-1, my-gateway-2, ...
 ```
 
-The `-` between `}}` and `{{` is literal text outside the template delimiters — this is valid syntax even though dashes cannot appear *inside* `{{ }}`.
+The `-` between `}}` and `{{` is literal text outside the template delimiters; this is valid syntax even though dashes cannot appear *inside* `{{ }}`.
 
 ##### Example: label-based routing
 
@@ -307,14 +307,14 @@ sync:
           type: dir
 ```
 
-A pod with label `site: ignition-blue` syncs from `services/ignition-blue/`, while `site: ignition-red` syncs from `services/ignition-red/` — same profile, different files.
+A pod with label `site: ignition-blue` syncs from `services/ignition-blue/`, while `site: ignition-red` syncs from `services/ignition-red/`: same profile, different files.
 
 :::note
-**Label and var key naming constraint:** Go's template engine requires map keys to be valid identifiers when accessed with dot notation. Keys must use only letters, digits, and underscores — **dashes, dots, and slashes are not supported**.
+**Label and var key naming constraint:** Go's template engine requires map keys to be valid identifiers when accessed with dot notation. Keys must use only letters, digits, and underscores (dashes, dots, and slashes are not supported).
 
-- `{{.Labels.site}}` ✅ — simple identifier
-- `{{.Labels.my-label}}` ❌ — parse error (`bad character '-'`)
-- `{{.Labels.app.kubernetes.io}}` ❌ — silently looks up key `"app"`, not `"app.kubernetes.io"`
+- `{{.Labels.site}}` ✅ (simple identifier)
+- `{{.Labels.my-label}}` ❌ (parse error: `bad character '-'`)
+- `{{.Labels.app.kubernetes.io}}` ❌ (silently looks up key `"app"`, not `"app.kubernetes.io"`)
 
 For K8s system labels with dots or slashes (e.g., `apps.kubernetes.io/pod-index`), use `{{.PodOrdinal}}` or a `vars` entry instead of `{{.Labels.*}}`.
 
@@ -387,9 +387,9 @@ my-gateway   main   1/1 synced   True    All gateways synced 5m
 
 Gateways progress through these sync states:
 
-1. **Pending** — initial sync completes (files written) but gateway hasn't been validated yet
-2. **Synced** — the Ignition scan API confirmed both `/scan/projects` and `/scan/config` returned HTTP 200
-3. **Error** — the scan API returned a non-200 status or was unreachable
+1. **Pending:** initial sync completes (files written) but gateway hasn't been validated yet
+2. **Synced:** the Ignition scan API confirmed both `/scan/projects` and `/scan/config` returned HTTP 200
+3. **Error:** the scan API returned a non-200 status or was unreachable
 
 The `AllGatewaysSynced` condition is `True` only when all discovered gateways report `Synced`.
 
@@ -401,5 +401,5 @@ The `AllGatewaysSynced` condition is `True` only when all discovered gateways re
 | `ProfilesValid` | All embedded profiles pass validation (no path traversal, no absolute paths) |
 | `AllGatewaysSynced` | All discovered gateway pods report `Synced` status |
 | `SidecarInjected` | All discovered gateway pods have the stoker-agent sidecar container |
-| `SSHHostKeyVerification` | SSH host key verification status — `True` when `knownHosts` is configured, `False` (warning) when SSH auth is used without it. Only present on CRs using SSH key authentication. |
+| `SSHHostKeyVerification` | SSH host key verification status: `True` when `knownHosts` is configured, `False` (warning) when SSH auth is used without it. Only present on CRs using SSH key authentication. |
 | `Ready` | `RefResolved`, `ProfilesValid`, and `AllGatewaysSynced` are all `True` |

--- a/docs/docs/reference/helm-values.md
+++ b/docs/docs/reference/helm-values.md
@@ -100,7 +100,7 @@ The webhook injects the agent sidecar into pods with annotation `stoker.io/injec
 | `webhookReceiver.ingress.ingressClassName` | string | `""` | Ingress class name (e.g. `nginx`, `traefik`, `alb`). Uses cluster default when empty. |
 | `webhookReceiver.ingress.annotations` | object | `{}` | Annotations for the Ingress resource (ingress controller config, cert-manager, etc.). |
 | `webhookReceiver.ingress.hosts` | list | `[]` | List of `{host, paths[]}` entries. Each path requires `path` and `pathType`. |
-| `webhookReceiver.ingress.tls` | list | `[]` | TLS configuration — list of `{secretName, hosts[]}` entries. |
+| `webhookReceiver.ingress.tls` | list | `[]` | TLS configuration: list of `{secretName, hosts[]}` entries. |
 
 The push receiver accepts `POST /webhook/{namespace}/{crName}` and auto-detects payload format from GitHub releases, ArgoCD notifications, Kargo promotions, or generic `{"ref": "..."}` bodies. If both HMAC and bearer token are configured, either method can authorize a request.
 

--- a/docs/docs/reference/troubleshooting.md
+++ b/docs/docs/reference/troubleshooting.md
@@ -14,24 +14,24 @@ description: Common issues, debug commands, and FAQ.
 
 **Checklist:**
 
-1. **Namespace label** — if `webhook.namespaceSelector.requireLabel=true` is set, ensure the namespace has `stoker.io/injection=enabled`:
+1. **Namespace label:** if `webhook.namespaceSelector.requireLabel=true` is set, ensure the namespace has `stoker.io/injection=enabled`:
    ```bash
    kubectl get namespace <ns> --show-labels
    ```
-   With the default configuration, no namespace label is needed — injection works in all namespaces except `kube-system` and `kube-node-lease`.
-2. **Pod annotation** — ensure the pod has `stoker.io/inject: "true"` (must be a string, not a boolean):
+   With the default configuration, no namespace label is needed; injection works in all namespaces except `kube-system` and `kube-node-lease`.
+2. **Pod annotation:** ensure the pod has `stoker.io/inject: "true"` (must be a string, not a boolean):
    ```bash
    kubectl get pod <pod> -n <ns> -o jsonpath='{.metadata.annotations}'
    ```
-3. **Webhook running** — check the controller pod logs for webhook server startup:
+3. **Webhook running:** check the controller pod logs for webhook server startup:
    ```bash
    kubectl logs -n stoker-system deploy/stoker-stoker-operator-controller-manager | grep webhook
    ```
-4. **cert-manager certificates** — the webhook requires a valid TLS certificate:
+4. **cert-manager certificates:** the webhook requires a valid TLS certificate:
    ```bash
    kubectl get certificate -n stoker-system
    ```
-5. **Timing** — the webhook only injects on pod creation. If the pod was created before the operator was installed, delete the pod and let the StatefulSet recreate it.
+5. **Timing:** the webhook only injects on pod creation. If the pod was created before the operator was installed, delete the pod and let the StatefulSet recreate it.
 
 ### Status stuck at Pending
 
@@ -39,11 +39,11 @@ description: Common issues, debug commands, and FAQ.
 
 **Checklist:**
 
-1. **Agent logs** — check for errors in the agent sidecar:
+1. **Agent logs:** check for errors in the agent sidecar:
    ```bash
    kubectl logs <pod> -n <ns> -c stoker-agent --tail=50
    ```
-2. **RBAC** — verify the agent RoleBinding exists (created automatically when `rbac.autoBindAgent.enabled=true`):
+2. **RBAC:** verify the agent RoleBinding exists (created automatically when `rbac.autoBindAgent.enabled=true`):
    ```bash
    kubectl get rolebinding -n <ns> | grep stoker-agent
    ```
@@ -52,11 +52,11 @@ description: Common issues, debug commands, and FAQ.
    kubectl create rolebinding stoker-agent -n <ns> \
      --clusterrole=stoker-agent --serviceaccount=<ns>:<service-account>
    ```
-3. **Secret mounts** — if using private repos, verify the git credentials secret exists:
+3. **Secret mounts:** if using private repos, verify the git credentials secret exists:
    ```bash
    kubectl get secret -n <ns>
    ```
-4. **API key** — verify the Ignition API key secret exists and is referenced correctly:
+4. **API key:** verify the Ignition API key secret exists and is referenced correctly:
    ```bash
    kubectl get secret gw-api-key -n <ns>
    ```
@@ -67,12 +67,12 @@ description: Common issues, debug commands, and FAQ.
 
 **Causes:**
 
-- **Invalid repo URL** — check for typos in `spec.git.repo`
-- **Auth failure** — the token/SSH key/GitHub App credentials are wrong or expired
-- **Network access** — the controller pod can't reach the git host (check network policies)
-- **Ref doesn't exist** — the specified branch or tag doesn't exist in the remote
-- **SSH host key mismatch** — if `knownHosts` is configured and the git server's key doesn't match, the connection is rejected. Re-scan the host: `ssh-keyscan <host> > known_hosts` and update the Secret.
-- **GitHub App exchange failed** — if the condition reason is `GitHubAppExchangeFailed`, check that the App ID, Installation ID, and PEM key are correct. Verify the app has **Contents: Read** permission and is installed on the target repository. Clock skew >60s between the controller and GitHub can also cause JWT validation failures.
+- **Invalid repo URL:** check for typos in `spec.git.repo`
+- **Auth failure:** the token/SSH key/GitHub App credentials are wrong or expired
+- **Network access:** the controller pod can't reach the git host (check network policies)
+- **Ref doesn't exist:** the specified branch or tag doesn't exist in the remote
+- **SSH host key mismatch:** if `knownHosts` is configured and the git server's key doesn't match, the connection is rejected. Re-scan the host: `ssh-keyscan <host> > known_hosts` and update the Secret.
+- **GitHub App exchange failed:** if the condition reason is `GitHubAppExchangeFailed`, check that the App ID, Installation ID, and PEM key are correct. Verify the app has **Contents: Read** permission and is installed on the target repository. Clock skew >60s between the controller and GitHub can also cause JWT validation failures.
 
 The condition message includes the retry interval (e.g., `retry in 30s`). Consecutive failures back off exponentially (30s → 60s → 120s → 240s → 5min cap). Fixing the root cause or triggering a webhook resets the backoff immediately.
 
@@ -86,7 +86,7 @@ kubectl logs -n stoker-system deploy/stoker-stoker-operator-controller-manager |
 
 **Symptoms:** `kubectl describe gs <name>` shows `SSHHostKeyVerification=False` with reason `HostKeyVerificationDisabled`.
 
-**Cause:** SSH key auth is configured without `knownHosts`, so connections use `InsecureIgnoreHostKey`. This is a security warning — connections are vulnerable to MITM attacks.
+**Cause:** SSH key auth is configured without `knownHosts`, so connections use `InsecureIgnoreHostKey`. Connections are vulnerable to MITM attacks.
 
 **Fix:** Add a `knownHosts` Secret. See the [SSH host key verification](../guides/git-authentication.md#ssh-host-key-verification) guide.
 
@@ -96,9 +96,9 @@ kubectl logs -n stoker-system deploy/stoker-stoker-operator-controller-manager |
 
 **Causes:**
 
-- **Scan API failure** — check gateway port and TLS settings match `spec.gateway.port` and `spec.gateway.tls`
-- **API key format** — the Ignition API key must be in `name:secret` format (e.g., `ignition-api-key:CYCSdRg...`), not just the secret portion
-- **Gateway not ready** — the Ignition gateway may still be starting up
+- **Scan API failure:** check gateway port and TLS settings match `spec.gateway.port` and `spec.gateway.tls`
+- **API key format:** the Ignition API key must be in `name:secret` format (e.g., `ignition-api-key:CYCSdRg...`), not just the secret portion
+- **Gateway not ready:** the Ignition gateway may still be starting up
 
 ```bash
 kubectl logs <pod> -n <ns> -c stoker-agent | grep -i "scan\|error"
@@ -111,8 +111,8 @@ kubectl logs <pod> -n <ns> -c stoker-agent | grep -i "scan\|error"
 | Code | Likely cause |
 |------|-------------|
 | 401 | API key missing, wrong format, or not loaded by gateway |
-| 404 | Wrong gateway port — the API is on a different port than configured |
-| 500 | Gateway internal error — check the Ignition gateway logs |
+| 404 | Wrong gateway port. The API is on a different port than configured. |
+| 500 | Gateway internal error. Check the Ignition gateway logs. |
 | Connection refused | Wrong port, TLS mismatch, or gateway not yet started |
 
 :::tip API key format
@@ -131,7 +131,7 @@ templating config/resources/core/image.png: template=true on binary file is not 
 
 **Cause:** A mapping with `template: true` matched a binary file (contains null bytes).
 
-**Fix:** Split the mapping into two — one for text files with `template: true`, another for binary files without it. Or exclude binary files with `excludePatterns`:
+**Fix:** Split the mapping into two: one for text files with `template: true`, another for binary files without it. Or exclude binary files with `excludePatterns`:
 
 ```yaml
 mappings:
@@ -186,7 +186,7 @@ templating config/some-file.json: resolving template in .../some-file.json: temp
    kubectl logs -n stoker-system deploy/stoker-stoker-operator-controller-manager | grep "GitHub App\|token"
    ```
 3. Verify the GitHub App has **Contents: Read** permission on the repository and is installed on the target repo.
-4. Check for clock skew — the JWT used for token exchange is valid for 60 seconds. A controller with clock skew >60s relative to GitHub will get 401 errors.
+4. Check for clock skew: the JWT used for token exchange is valid for 60 seconds. A controller with clock skew >60s relative to GitHub will get 401 errors.
 
 ### JSON patch errors
 
@@ -245,13 +245,13 @@ mapping[0]: type mismatch: spec says "dir" but /repo/config/versions/.versions.j
 
 **Checklist:**
 
-1. **Previous logs** — check the last crash output:
+1. **Previous logs:** check the last crash output:
    ```bash
    kubectl logs <pod> -n <ns> -c stoker-agent --previous
    ```
-2. **Resource limits** — the default agent has no resource limits. If limits are set too low, OOM kills can occur.
-3. **Volume mounts** — the agent requires `/ignition-data/` to be mounted from the gateway's data volume.
-4. **ConfigMap missing** — if the GatewaySync CR was deleted while the pod is running, the metadata ConfigMap no longer exists.
+2. **Resource limits:** the default agent has no resource limits. If limits are set too low, OOM kills can occur.
+3. **Volume mounts:** the agent requires `/ignition-data/` to be mounted from the gateway's data volume.
+4. **ConfigMap missing:** if the GatewaySync CR was deleted while the pod is running, the metadata ConfigMap no longer exists.
 
 ## Debug commands
 


### PR DESCRIPTION
### 📖 Background
The docs had ~169 em dashes spread across 17 files. Most were discretionary prose asides or `**Bold** — description` list patterns that read better with conventional punctuation. A smaller number were voice mismatches: impersonal, wordy, or padded passages that didn't match the direct, action-first style established in `introduction.md`. This pass removes the friction without touching technical meaning, structure, headings, or code samples.

### ⚙️ Changes
- Converted ~141 discretionary em dashes to appropriate punctuation across 16 files: `**Term** — description` patterns become `**Term:** description`; prose asides get commas, semicolons, periods, or parentheses depending on the clause relationship. Table-cell placeholder dashes (`| — |`) and em dashes inside code blocks/YAML comments are untouched.
- Trimmed wordiness in `guides/json-patches.md` and `guides/content-templating.md` (intro paragraphs and a few verbose aside constructions).
- Aligned prose voice across all files to match `introduction.md`: shorter sentences, imperative-first, no padding.
- Minimal footprint on `overview/concepts.md` (only em dashes changed, no prose restructuring) to stay clear of concurrent work on that file's tone.

### 📝 Reviewer Notes
28 em dashes were intentionally kept: they are all either `| — |` default-column placeholders in reference tables, or em dashes inside fenced code blocks/YAML comments (e.g., `# optional — enables host key verification`). None of these are prose choices and none affect rendering.

The `[Link](url) — description` next-steps pattern throughout the docs has been converted to `[Link](url): description` consistently. This was the largest single pattern after table placeholders.

### ☑️ Testing Notes
- `cd docs && npm run build` passes cleanly (no broken links, no MDX errors).
- Verified all 16 changed files have no remaining discretionary em dashes via `grep -rc "—" docs/docs/`.