### PR TITLE
fix(docs): correct github app token-expiry metric name and labels

### DIFF
--- a/docs/docs/guides/monitoring.md
+++ b/docs/docs/guides/monitoring.md
@@ -28,7 +28,7 @@ The controller exposes metrics on port 8443 (the same HTTPS endpoint used by con
 | `stoker_controller_gateway_sync_status` | Gauge | `name`, `namespace`, `gateway` | Per-gateway sync state (0=Pending, 1=Synced, 2=Error, 3=MissingSidecar) |
 | `stoker_controller_gateway_last_sync_timestamp_seconds` | Gauge | `name`, `namespace`, `gateway` | Unix timestamp of the last agent sync per gateway |
 | `stoker_controller_gateways_missing_sidecar` | Gauge | `name`, `namespace` | Count of gateways without the stoker-agent sidecar |
-| `stoker_controller_github_app_token_expiry` | Gauge | `name`, `namespace` | Unix timestamp when the cached GitHub App token expires |
+| `stoker_controller_github_app_token_expiry_timestamp_seconds` | Gauge | `app_id`, `installation_id` | Unix timestamp when the cached GitHub App token expires |
 
 ### Agent metrics
 


### PR DESCRIPTION
### Background

The GitHub App token-expiry metric was documented with the wrong name and label set. Any PromQL query or alert rule built from the doc returned no data because the metric name did not exist in Prometheus.

### Changes

- Corrected metric name from `stoker_controller_github_app_token_expiry` to `stoker_controller_github_app_token_expiry_timestamp_seconds`
- Corrected labels from `name`/`namespace` to `app_id`/`installation_id`

Both values verified against `internal/controller/metrics.go` (line 87-95) where the `githubAppTokenExpiry` gauge is registered.

### Reviewer Notes

Only `docs/docs/guides/monitoring.md` was touched — one row in the controller metrics table. No PromQL examples for this metric exist in the doc, so no query updates were needed.

### Testing Notes

- `cd docs && npm run build` passes locally with the change applied.