### PR TITLE
docs: document post-commission re-sync, agent backoff, and webhook HA

### DIFF
--- a/docs/docs/overview/architecture.md
+++ b/docs/docs/overview/architecture.md
@@ -74,6 +74,14 @@ flowchart LR
 6. **Scan:** calls the Ignition REST API (`/scan/projects` and `/scan/config`) so the gateway reloads without restart
 7. **Report:** writes sync results (commit, file counts, errors) to the status ConfigMap
 
+**Commit detection** is dual-track: the metadata ConfigMap is polled every 3 seconds independent of `syncPeriod`, so new commits are detected within 3 seconds of the controller writing them. `syncPeriod` drives a separate fallback timer that fires even when the ConfigMap has not changed.
+
+**Initial sync:** the first cycle skips the scan step and attempts a health check instead (expected to fail; the gateway has not started yet). The agent writes status `Pending`. Status advances to `Synced` after the post-commission re-sync completes.
+
+#### Post-commission re-sync
+
+When deployed as a native sidecar, the agent syncs files before the gateway container starts. Ignition's commissioning process (first boot) overwrites config resources, including `security-properties`, with factory defaults. To restore git-sourced config after commissioning completes, the agent polls the gateway TCP port every 5 seconds using a raw port check rather than the authenticated health endpoint (commissioning may overwrite the security settings that grant API token access). Once the port responds, the agent runs a second full sync+scan cycle. This restores any config that commissioning overwrote and triggers a gateway reload without restart. The `Pending` status from the initial sync clears at this point.
+
 #### Three-layer architecture
 
 The agent is split into three layers to keep concerns separate:
@@ -108,6 +116,8 @@ POST /webhook/{namespace}/{crName}
 It auto-detects the payload format (GitHub, ArgoCD, Kargo, or generic `{"ref": "..."}`) and annotates the GatewaySync CR with the requested ref. The controller's reconciliation predicate picks up the annotation change and triggers an immediate sync.
 
 HMAC signature validation via `X-Hub-Signature-256` is supported when configured.
+
+The receiver runs on every controller replica (`NeedLeaderElection()` returns `false`), so the Service load-balances across all pods and no webhook is dropped if it reaches a non-leader pod.
 
 ## Next steps
 

--- a/docs/docs/reference/troubleshooting.md
+++ b/docs/docs/reference/troubleshooting.md
@@ -99,9 +99,10 @@ kubectl logs -n stoker-system deploy/stoker-stoker-operator-controller-manager |
 - **Scan API failure:** check gateway port and TLS settings match `spec.gateway.port` and `spec.gateway.tls`
 - **API key format:** the Ignition API key must be in `name:secret` format (e.g., `ignition-api-key:CYCSdRg...`), not just the secret portion
 - **Gateway not ready:** the Ignition gateway may still be starting up
+- **Agent backoff:** on consecutive git-fetch or sync failures, the agent backs off exponentially (30s → 60s → 120s → 240s → 5min cap). While backing off, incoming sync triggers are dropped and the agent records `stoker_agent_sync_skipped_total{reason="backoff"}`. The backoff resets automatically on the next successful sync. Check agent logs for `backing off` messages to confirm this state.
 
 ```bash
-kubectl logs <pod> -n <ns> -c stoker-agent | grep -i "scan\|error"
+kubectl logs <pod> -n <ns> -c stoker-agent | grep -i "scan\|error\|backing off"
 ```
 
 ### Scan failures (non-200 response)


### PR DESCRIPTION
### 📖 Background

Five runtime behaviors were either undocumented or inaccurately described in architecture.md and troubleshooting.md. All five were confirmed against the controller/agent source before editing.

### ⚙️ Changes

**architecture.md**

- Adds a note after the sync-flow steps explaining that the initial sync skips the scan step, runs a health check instead (expected to fail; the gateway has not started), and writes status `Pending`. The `Pending` status clears after the post-commission re-sync.
- Adds a "Post-commission re-sync" subsection: after startup the agent polls the gateway TCP port every 5 seconds (raw port check, not the authenticated API endpoint, because commissioning may overwrite the security-properties that grant token access). Once the port responds, a second full sync+scan cycle runs to restore git-sourced config and trigger a gateway reload without restart.
- Adds a note that commit detection is dual-track: a 3-second ConfigMap poller independent of `syncPeriod` for fast commit detection, plus a separate fallback timer governed by `syncPeriod`.
- Adds one sentence to the webhook receiver section: the receiver runs on all controller replicas (`NeedLeaderElection()` returns `false`) so the Service can load-balance without dropping webhooks routed to non-leader pods.

**troubleshooting.md**

- Adds an "Agent backoff" bullet under AllGatewaysSynced=False: consecutive git-fetch/sync failures back off exponentially (30s → 60s → 120s → 240s → 5min cap), matching the same sequence already documented for the controller. While backing off the agent emits `stoker_agent_sync_skipped_total{reason="backoff"}`.

### 📝 Reviewer Notes

Each finding was verified line-by-line against source before writing:

- Finding 1 (initial sync Pending): `agent.go:568-600` — `!isInitial` gates scan; `isInitial` path sets `SyncStatusPending`
- Finding 2 (post-commission re-sync): `agent.go:209-245` — `postCommissionSync()`, `PortCheck()` every 5s, then `syncOnce(..., false, ...)`
- Finding 3 (agent backoff): `agent.go:337` — `min(30*time.Second<<(n-1), 5*time.Minute)`; metric label key confirmed in `metrics.go:184`
- Finding 4 (webhook on all replicas): `receiver.go:44` — `return false`
- Finding 5 (3s ConfigMap poller): `watcher.go:101` — `time.NewTicker(3 * time.Second)` in its own goroutine, separate from the `w.period` fallback

No em dashes in prose. No invented terminology.

### ☑️ Testing Notes

- `cd docs && npm run build` passes locally
- Edits are in `docs/docs/overview/architecture.md` and `docs/docs/reference/troubleshooting.md` only