### PR TITLE
ci: build docs on PRs touching docs/

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,26 @@
+name: Build Docs
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install dependencies
+        working-directory: docs
+        run: npm ci
+
+      - name: Build
+        working-directory: docs
+        run: npm run build


### PR DESCRIPTION
### 📖 Background
The docs site (Docusaurus under `docs/`) had no build validation on pull requests. The existing Deploy Docs workflow only triggers on push to `main`, meaning a PR could introduce a broken docs build or search regression and CI would stay green. This closes that gap.

### ⚙️ Changes
Adds `.github/workflows/docs-build.yml` — a minimal build-only workflow that triggers on `pull_request` when any path under `docs/**` changes. It mirrors the node setup from `docs.yml` exactly (`actions/checkout@v7`, `actions/setup-node@v6`, `node-version: 24`, npm cache on `docs/package-lock.json`) and runs `npm ci && npm run build` in `docs/`. No deploy steps.

### 📝 Reviewer Notes
- Trigger uses a `paths: ["docs/**"]` filter, so the workflow only runs when docs content actually changes — no noise on Go or chart-only PRs.
- Action versions (`checkout@v7`, `setup-node@v6`) match the updated `docs.yml` from #168.
- This PR only touches `.github/workflows/` so the new workflow will not self-trigger on this PR (expected — `.github/workflows/` is not under `docs/**`).

### ☑️ Testing Notes
- `npm ci && npm run build` in `docs/` succeeded locally — build output confirmed clean.
- On any future PR that modifies files under `docs/`, the "Build Docs" check will appear and block merge if the build fails.