### PR TITLE
docs: move upgrading guide to Getting Started, surface changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+> **Upgrading?** See the [Upgrading guide](https://ia-eknorr.github.io/stoker-operator/upgrading) for the version policy, Kubernetes compatibility matrix, the CRD-on-`helm upgrade` caveat, and GitOps / ArgoCD specifics.
+
 ## [v0.6.1] - 2026-06-12
 
 A correctness, security, and observability hardening release. No new features, CRD changes, or breaking changes; safe to upgrade in place from v0.6.0.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -87,7 +87,7 @@ helm upgrade stoker oci://ghcr.io/ia-eknorr/charts/stoker-operator \
 Helm installs CRDs from a chart's `crds/` directory only on first install. `helm upgrade` never updates them, so a `GatewaySync` schema change between versions is skipped silently unless you apply it by hand.
 :::
 
-See the [Upgrading guide](./guides/upgrading.md) for the full procedure: the version policy, the Kubernetes compatibility matrix, applying CRD changes, and GitOps / ArgoCD specifics.
+See the [Upgrading guide](./upgrading.md) for the full procedure: the version policy, the Kubernetes compatibility matrix, applying CRD changes, and GitOps / ArgoCD specifics.
 
 ## Uninstalling
 

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 3
 title: Upgrading
 description: Move Stoker between versions safely, including the CRD-on-helm-upgrade footgun and the Kubernetes compatibility matrix.
 ---
@@ -75,7 +75,7 @@ Use this for any patch bump inside a minor (for example `0.6.0` to `0.6.1`).
    kubectl get gs -A
    ```
 
-   See [Troubleshooting](../reference/troubleshooting.md) if a `GatewaySync` does not return to `Ready`.
+   See [Troubleshooting](./reference/troubleshooting.md) if a `GatewaySync` does not return to `Ready`.
 
 ### Worked example: `0.5.1` to `0.6.1`
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -118,6 +118,10 @@ const config: Config = {
               href: "https://github.com/ia-eknorr/stoker-operator",
             },
             {
+              label: "Changelog",
+              href: "https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md",
+            },
+            {
               label: "Helm Chart",
               href: "https://github.com/ia-eknorr/stoker-operator/tree/main/charts/stoker-operator",
             },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -12,7 +12,7 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "Getting Started",
       collapsed: false,
-      items: ["quickstart", "installation"],
+      items: ["quickstart", "installation", "upgrading"],
     },
     {
       type: "category",
@@ -26,7 +26,6 @@ const sidebars: SidebarsConfig = {
         "guides/webhook-sync",
         "guides/monitoring",
         "guides/multi-site-deployment",
-        "guides/upgrading",
       ],
     },
     {


### PR DESCRIPTION
Follow-up to #180.

### 📖 Background

Two placement gaps surfaced after #180 shipped:

- The Upgrading guide landed under **Guides**, but Guides is feature/task how-tos (git auth, templating, patches, webhooks, monitoring). Upgrading is operational lifecycle content that pairs with **Installation** instead.
- The **CHANGELOG was not reachable from the docs site at all** (not in navbar, sidebar, or footer). The guide links out to it, but nothing linked back, and a reader on the site had no entry point to per-release notes.

### ⚙️ Changes

- Move `docs/docs/guides/upgrading.md` to `docs/docs/upgrading.md` and place it in the **Getting Started** sidebar category right after Installation. URL changes from `/guides/upgrading` to `/upgrading`. Internal links updated accordingly (`installation.md` -> the guide, and the guide -> Troubleshooting).
- Add a **Changelog** link to the site footer (More column).
- Add a one-line pointer at the top of `CHANGELOG.md` back to the Upgrading guide, so the procedure and the per-release notes reference each other.

### 📝 Reviewer Notes

The page only went live minutes ago under `/guides/upgrading` and isn't linked externally, so I did not add a client redirect for the old URL. Say the word if you want one (needs `@docusaurus/plugin-client-redirects`).

### ☑️ Testing Notes

`npm run build` in `docs/` succeeds with `onBrokenLinks: "throw"`, so the moved page and every updated link resolve. No Go or chart files touched.