### PR TITLE
docs: repoint ia-eknorr references to knorrlabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-> **Upgrading?** See the [Upgrading guide](https://ia-eknorr.github.io/stoker-operator/upgrading) for the version policy, Kubernetes compatibility matrix, the CRD-on-`helm upgrade` caveat, and GitOps / ArgoCD specifics.
+> **Upgrading?** See the [Upgrading guide](https://knorrlabs.github.io/stoker-operator/upgrading) for the version policy, Kubernetes compatibility matrix, the CRD-on-`helm upgrade` caveat, and GitOps / ArgoCD specifics.
 
 ## [v0.6.1] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/ia-eknorr/stoker-operator/actions/workflows/unit-test.yml"><img src="https://github.com/ia-eknorr/stoker-operator/actions/workflows/unit-test.yml/badge.svg" alt="Test"></a>
   <a href="https://github.com/ia-eknorr/stoker-operator/releases/latest"><img src="https://img.shields.io/github/v/release/ia-eknorr/stoker-operator" alt="Release"></a>
   <a href="https://github.com/ia-eknorr/stoker-operator/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"></a>
-  <a href="https://ia-eknorr.github.io/stoker-operator/"><img src="https://img.shields.io/badge/docs-ia--eknorr.github.io-blue" alt="Docs"></a>
+  <a href="https://knorrlabs.github.io/stoker-operator/"><img src="https://img.shields.io/badge/docs-knorrlabs.github.io-blue" alt="Docs"></a>
   <a href="https://goreportcard.com/report/github.com/ia-eknorr/stoker-operator"><img src="https://goreportcard.com/badge/github.com/ia-eknorr/stoker-operator" alt="Go Report Card"></a>
 </p>
 
@@ -39,7 +39,7 @@ helm install stoker oci://ghcr.io/ia-eknorr/charts/stoker-operator \
   -n stoker-system --create-namespace
 ```
 
-For a complete walkthrough — from installing the operator to syncing projects to an Ignition gateway — see the **[Quickstart Guide](https://ia-eknorr.github.io/stoker-operator/quickstart)**.
+For a complete walkthrough — from installing the operator to syncing projects to an Ignition gateway — see the **[Quickstart Guide](https://knorrlabs.github.io/stoker-operator/quickstart)**.
 
 ## Architecture
 
@@ -63,7 +63,7 @@ flowchart LR
 
 | CRD | Short Name | Description |
 | --- | --- | --- |
-| [`GatewaySync`](https://ia-eknorr.github.io/stoker-operator/reference/gatewaysync-cr) | `gs` | Defines the git repository, auth, polling, sync profiles, and gateway connection settings |
+| [`GatewaySync`](https://knorrlabs.github.io/stoker-operator/reference/gatewaysync-cr) | `gs` | Defines the git repository, auth, polling, sync profiles, and gateway connection settings |
 
 ## Development
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   tagline: "Git-driven configuration sync for Ignition SCADA gateways",
   favicon: "img/logo.png",
 
-  url: "https://ia-eknorr.github.io",
+  url: "https://knorrlabs.github.io",
   baseUrl: "/stoker-operator/",
 
   organizationName: "knorrlabs",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   url: "https://ia-eknorr.github.io",
   baseUrl: "/stoker-operator/",
 
-  organizationName: "ia-eknorr",
+  organizationName: "knorrlabs",
   projectName: "stoker-operator",
 
   future: {
@@ -77,7 +77,7 @@ const config: Config = {
           routeBasePath: "/",
           sidebarPath: "./sidebars.ts",
           editUrl:
-            "https://github.com/ia-eknorr/stoker-operator/tree/main/docs/",
+            "https://github.com/knorrlabs/stoker-operator/tree/main/docs/",
         },
         blog: false,
         theme: {
@@ -103,7 +103,7 @@ const config: Config = {
           label: "Docs",
         },
         {
-          href: "https://github.com/ia-eknorr/stoker-operator",
+          href: "https://github.com/knorrlabs/stoker-operator",
           label: "GitHub",
           position: "right",
         },
@@ -125,15 +125,15 @@ const config: Config = {
           items: [
             {
               label: "GitHub",
-              href: "https://github.com/ia-eknorr/stoker-operator",
+              href: "https://github.com/knorrlabs/stoker-operator",
             },
             {
               label: "Changelog",
-              href: "https://github.com/ia-eknorr/stoker-operator/blob/main/CHANGELOG.md",
+              href: "https://github.com/knorrlabs/stoker-operator/blob/main/CHANGELOG.md",
             },
             {
               label: "Helm Chart",
-              href: "https://github.com/ia-eknorr/stoker-operator/tree/main/charts/stoker-operator",
+              href: "https://github.com/knorrlabs/stoker-operator/tree/main/charts/stoker-operator",
             },
             {
               label: "Ignition Helm Chart",


### PR DESCRIPTION
## Why

The repo moved to the `knorrlabs` org. GitHub **Pages** URLs do not redirect (unlike repo URLs), so every hardcoded `ia-eknorr.github.io/...` link now 404s and the docs link-check fails.

## What

- Repoint `ia-eknorr.github.io` → `knorrlabs.github.io` (Pages links + Docusaurus `url`)
- Update `organizationName` (and config `editUrl`) to `knorrlabs`

Redirect-covered references (go.mod module path, Go imports, repo URLs) are intentionally left for the broader Phase 3 sweep.