### PR TITLE
chore: add OCI source label to link GHCR packages to the repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
 # Use distroless as minimal base image to package the binaries
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+# Links the GHCR package to this repo so it inherits repo permissions on push
+LABEL org.opencontainers.image.source="https://github.com/knorrlabs/stoker-operator"
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/agent .

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -17,6 +17,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
 
 # Alpine with git and openssh — no shell session risk with readOnlyRootFilesystem
 FROM alpine:3.24
+# Links the GHCR package to this repo so it inherits repo permissions on push
+LABEL org.opencontainers.image.source="https://github.com/knorrlabs/stoker-operator"
 RUN apk add --no-cache git openssh-client nss_wrapper
 WORKDIR /
 COPY --from=builder /workspace/agent .


### PR DESCRIPTION
## Why

The `ia-eknorr` → `knorrlabs` org migration severed the link between the GHCR packages and this repository. As a result, the v0.7.0 release workflow's `GITHUB_TOKEN` was denied write access (`permission_denied: write_package`) and the image push failed — the release only went through after the repo was manually granted package access in each package's settings.

That manual grant works but is fragile: it has to be redone by hand after any future org/repo move, and there's nothing in the repo declaring the relationship.

## What

Adds `LABEL org.opencontainers.image.source="https://github.com/knorrlabs/stoker-operator"` to the runtime stage of both `Dockerfile` and `Dockerfile.agent`. GHCR reads this label on push and auto-links the package to the repo, so the package inherits repo permissions automatically instead of relying on a manual grant.

This matches the existing convention in `Dockerfile.agent`, which already hardcodes the `github.com/knorrlabs/stoker-operator` module path in the agent ldflags.

## Verification

The label takes effect on the next image push (next tagged release). The current v0.7.0 images are already published via the manual grant, so nothing is broken in the meantime.