### PR TITLE
docs(upgrading): note that upgrading the controller doesn't update running agents

### DIFF
--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -1,14 +1,15 @@
 ---
 sidebar_position: 3
 title: Upgrading
-description: Move Stoker between versions safely, including the CRD-on-helm-upgrade footgun and the Kubernetes compatibility matrix.
+description: Move Stoker between versions safely, including the CRD-on-helm-upgrade footgun, why upgrading the controller does not upgrade the running agents, and the Kubernetes compatibility matrix.
 ---
 
 # Upgrading
 
-Most Stoker upgrades are a single `helm upgrade`. The two things that are not obvious, and that this guide makes explicit, are:
+Most Stoker upgrades are a single `helm upgrade`. The three things that are not obvious, and that this guide makes explicit, are:
 
 - **`helm upgrade` never updates the `GatewaySync` CRD.** Helm only installs CRDs from a chart's `crds/` directory on first install. A CRD schema change between versions is silently skipped unless you apply it by hand.
+- **Upgrading the controller does not upgrade the running agents.** The `stoker-agent` sidecar is injected at gateway-pod creation, so an already-running gateway keeps its old agent image until its pod is recreated — even after the controller is on the new version and `GatewaySync` reports `Ready`.
 - **Each release builds against a specific Kubernetes client version**, which sets the API-server versions it officially supports.
 
 Start with the [routine in-minor upgrade](#routine-in-minor-upgrade-helm). Cross a minor (`0.6.x` to `0.7.x`) only after the [pre-flight](#pre-flight-crossing-a-minor). If you run Stoker under ArgoCD, read the [GitOps appendix](#gitops--argocd-appendix) as well.
@@ -77,9 +78,36 @@ Use this for any patch bump inside a minor (for example `0.6.0` to `0.6.1`).
 
    See [Troubleshooting](./reference/troubleshooting.md) if a `GatewaySync` does not return to `Ready`.
 
+   A `Ready` `GatewaySync` here confirms the **controller** upgrade only. The agent sidecars in already-running gateways are still on the old version — see [Updating the agent sidecars](#updating-the-agent-sidecars).
+
 ### Worked example: `0.5.1` to `0.6.1`
 
 A two-minor jump that is still a clean upgrade. `0.6.0` removed the `stoker.io/agent-image` pod annotation (see the [pre-flight](#pre-flight-crossing-a-minor) below) and `0.5.2` raised the Kubernetes baseline to 1.36 libraries, so confirm the cluster is on k8s 1.35+ first. Neither `0.5.2`, `0.6.0`, nor `0.6.1` changed the `GatewaySync` CRD, so step 3 stays a no-op. After `helm upgrade`, each `GatewaySync` re-resolves its ref and the agents resync.
+
+## Updating the agent sidecars
+
+`helm upgrade` (or an ArgoCD sync) rolls the **controller** to the new version. It does **not** touch the `stoker-agent` sidecar in gateway pods that are already running.
+
+The webhook injects the sidecar at pod **creation**, so a running gateway keeps whatever agent image it was admitted with. After the controller upgrade, `GatewaySync` returns to `Ready` and the agents keep syncing config — but they are still the **old agent version**. This is easy to miss, and it matters most when a release changes the agent image: for example `v0.7.0` re-homes the images to `ghcr.io/knorrlabs/...`, but existing gateways keep pulling `ghcr.io/ia-eknorr/stoker-agent` until their pods are recreated.
+
+To roll the agents onto the new version, recreate the gateway pods once the controller is healthy:
+
+```bash
+kubectl rollout restart statefulset/<gateway> -n <namespace>
+```
+
+To keep a replica serving during the cycle, delete the pods one at a time instead, waiting for each to become `Ready` before the next. Confirm the new image landed:
+
+```bash
+kubectl get pod <gateway-pod> -n <namespace> \
+  -o jsonpath='{range .spec.initContainers[?(@.name=="stoker-agent")]}{.image}{end}'
+```
+
+Watch that every `GatewaySync` stays `Ready` / synced through the cycle. Until the pods are recreated you are running a new controller against old agents; check the [CHANGELOG](https://github.com/knorrlabs/stoker-operator/blob/main/CHANGELOG.md) for any controller/agent protocol change across the bump, and don't leave the data plane on the old agent longer than necessary.
+
+:::note ArgoCD
+`kubectl rollout restart` writes a `restartedAt` annotation into the StatefulSet's pod template, which ArgoCD sees as drift and may revert under `selfHeal`. To recreate gateway pods without changing tracked spec, **delete the pods** (one at a time) instead — the StatefulSet recreates them with the new sidecar injected and ArgoCD stays in sync.
+:::
 
 ## Pre-flight: crossing a minor
 


### PR DESCRIPTION
## What

Adds an **Updating the agent sidecars** section (and a heads-up bullet + a cross-reference from the verify step) to the Upgrading guide, making explicit that `helm upgrade` / an ArgoCD sync rolls the **controller** only — the `stoker-agent` sidecars in already-running gateway pods are **not** updated until those pods are recreated.

## Why

The guide currently implies an upgrade is complete once the controller is healthy and `GatewaySync` returns to `Ready` ("after `helm upgrade`… the agents resync"). But the sidecar is injected by the webhook at pod **creation**, so existing gateways keep their old agent image indefinitely — `GatewaySync` still reports `Ready`, masking the skew.

This bites hardest on exactly the kind of release the guide is meant to shepherd. Upgrading a real deployment to **v0.7.0** (the knorrlabs image re-home), the controller moved to `ghcr.io/knorrlabs/stoker-operator:0.7.0` and `GatewaySync` went green, but all gateway pods kept running `ghcr.io/ia-eknorr/stoker-agent:0.5.1`. Nothing in the guide tells you to recreate the gateway pods to actually land the new agent — so a reader would reasonably believe the image migration was finished while the data plane was still on the old org.

## Changes

- New `## Updating the agent sidecars` section: why it happens, how to recreate the pods (`rollout restart`, or delete one-at-a-time to keep a replica serving), how to verify the new sidecar image, and a note to watch `GatewaySync` through the cycle.
- ArgoCD note: prefer deleting pods over `kubectl rollout restart`, since the latter writes a `restartedAt` annotation the StatefulSet template that `selfHeal` will revert.
- Intro "things that aren't obvious" list and the routine-upgrade verify step now point at the new section; frontmatter `description` updated to match.

Docs-only; no template or behavior changes.
